### PR TITLE
Iss002: fix default noise regression/classification bug

### DIFF
--- a/R/construct_noise.R
+++ b/R/construct_noise.R
@@ -23,6 +23,30 @@ construct_noise <- function(
     
   }
   
+  if (
+    is.null(default_regression_noise) & 
+    is.null(default_classification_noise) & 
+    is.null(custom_noise)
+  ) {
+    
+    warning("No noise specified, using default noise() object.")
+    
+  }
+  
+  if (is.null(default_regression_noise)) { 
+  
+    default_regression_noise <- noise(add_noise = FALSE, 
+                                      mode = "regression")
+      
+  }
+  
+  if (is.null(default_classification_noise)) { 
+    
+    default_classification_noise <- noise(add_noise = FALSE, 
+                                          mode = "classification")
+    
+  }
+  
   # create vectors that we will use below
   visit_sequence <- roadmap[["visit_sequence"]][["visit_sequence"]]
   mode <- .extract_mode(roadmap)
@@ -36,20 +60,6 @@ construct_noise <- function(
     type_check_func = .is_noise,
     obj_name = "noise(s)"
   )
-  
-  if (
-    is.null(default_regression_noise) & 
-    is.null(default_classification_noise) & 
-    is.null(custom_noise)
-  ) {
-    
-    warning("No noise specified, using default noise() object.")
-    return(
-      purrr::map(purrr::set_names(visit_sequence), \(x) { noise() })
-    )
-    
-    
-  }
   
   # create list of default noise according to regression / classification
   synth_noise <- purrr::map(


### PR DESCRIPTION
Addresses #2 

Example issue fix: 

```
acs_conf <- acs_conf |>
  dplyr::select(-gq) |>
  tidyr::drop_na()

acs_start <- acs_start |>
  dplyr::select(-gq) |>
  tidyr::drop_na()

# roadmap
roadmap <- roadmap(
  conf_data = acs_conf,
  start_data = acs_start
)

schema <- roadmap$schema

rf_mod_regression <- parsnip::rand_forest(trees = 500, min_n = 1) %>%
  parsnip::set_engine(engine = "ranger") %>%
  parsnip::set_mode(mode = "regression") %>%
  parsnip::set_args(quantreg = TRUE)

rf_mod_classification <- parsnip::rand_forest(trees = 500, min_n = 1) %>%
  parsnip::set_engine(engine = "ranger") %>%
  parsnip::set_mode(mode = "classification")
constraints_df_num <- 
  tibble::tribble(~var, ~min, ~max, ~conditions,
                  "age", 0, Inf, "TRUE",
                  "age", 40, Inf, "famsize == 1"
  )

constraints <- constraints(
  schema = schema,
  constraints_df_num = constraints_df_num,
  max_z_num = 0
)

# synth_spec
synth_spec <- synth_spec(
  default_regression_model = rf_mod_regression,
  default_classification_model = rf_mod_classification,
  default_regression_sampler = sample_ranger,
  default_classification_sampler = sample_ranger,
  default_regression_noise = noise(
    add_noise = TRUE,
    noise_func = add_noise_kde,
    exclusions = 0,
    n_ntiles = 2
  )
)

# presynth
presynth <- presynth(
  roadmap = roadmap,
  synth_spec = synth_spec
)

# no error here
synth <- synthesize(presynth)
```

```
── R CMD check results ───── tidysynthesis 0.1.0 ────
Duration: 36.1s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

R CMD check succeeded
```