### PR TITLE
Iss010: update print.constraints() to display categorical constraints

### DIFF
--- a/R/constraints.R
+++ b/R/constraints.R
@@ -603,18 +603,35 @@ reset_constraints <- function(roadmap) {
 #' @export 
 print.constraints <- function(x, ...) {
   
-  constraint_conditions <- purrr::map_int(x$constraints_num, .f = \(z) { 
+  # print numeric constraint conditions
+  constraint_conditions_num <- purrr::map_int(x$constraints_num, .f = \(z) { 
     
     if (is.data.frame(z)) { return( base::nrow(z)) } else { return(0) }
     
   }) %>%
     stats::setNames(names(x$constraints_num))
   
-  cat("Constraints specified per variable: \n")
+  cat("Numeric constraints specified per variable: \n")
   
-  for (n in names(constraint_conditions)) {
+  for (n in names(constraint_conditions_num)) {
     
-    cat(paste0(n, ": ", constraint_conditions[[n]], "\n"))
+    cat(paste0(n, ": ", constraint_conditions_num[[n]], "\n"))
+    
+  }
+  
+  # print categorical constraint conditions
+  constraint_conditions_cat <- purrr::map_int(x$constraints_cat, .f = \(z) { 
+    
+    if (is.data.frame(z)) { return( base::nrow(z)) } else { return(0) }
+    
+  }) %>%
+    stats::setNames(names(x$constraints_cat))
+  
+  cat("Categorical constraints specified per variable: \n")
+  
+  for (n in names(constraint_conditions_cat)) {
+    
+    cat(paste0(n, ": ", constraint_conditions_cat[[n]], "\n"))
     
   }
   

--- a/tests/testthat/test-constraints.R
+++ b/tests/testthat/test-constraints.R
@@ -290,13 +290,27 @@ test_that("print.constraints", {
     
   }
   
+  for (eo in c("vs: 0", "am: 0", "gear: 0")) {
+    
+    expect_output(print(constraints_defaults, eo))
+    
+  }
+  
   constraints_custom <- constraints(
     schema = schema, 
     constraints_df_num = constraints_df_num, 
-    max_z_num = 1
+    max_z_num = 1,
+    constraints_df_cat = constraints_df_cat,
+    max_z_cat = 2
   )
   
   for (eo in c("mpg: 3", "disp: 1", "carb: 1")) {
+    
+    expect_output(print(constraints_custom, eo))
+    
+  }
+  
+  for (eo in c("vs: 1", "am: 0", "gear: 2")) {
     
     expect_output(print(constraints_custom, eo))
     


### PR DESCRIPTION
Addresses #10 

Example code: 
```
data <- dplyr::select(mtcars, cyl, mpg, disp, vs, gear) %>%
  dplyr::mutate(
    vs = factor(vs, levels = c("0", "1", "2")),
    gear = factor(gear)
  ) 

start_data <- dplyr::select(data, cyl, mpg)

constraints_df_cat <-  tibble::tribble(
  ~var, ~allowed, ~forbidden, ~conditions,
  "gear", NA, "5", "TRUE",
  "gear", "3", NA, "cyl == 8"
)

roadmap1 <- roadmap(conf_data = data, 
                    start_data = start_data) %>%
  update_constraints(constraints_df_cat = constraints_df_cat,
                     max_z_cat = 2)

print(roadmap1$constraints)
```

Example output: 
```
Numeric constraints specified per variable: 
disp: 0
Categorical constraints specified per variable: 
vs: 1
gear: 2
```

```
── R CMD check results ─────────── tidysynthesis 0.1.0 ────
Duration: 34.5s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

R CMD check succeeded
```

```
> covr::package_coverage()
tidysynthesis Coverage: 100.00%
```