### PR TITLE
`add_noise_kde()` `sd_scale` parameter

### DIFF
--- a/R/add_noise_kde.R
+++ b/R/add_noise_kde.R
@@ -218,6 +218,8 @@
 #' one-to-one relationship; "random" adds a small random perturbation to the 
 #' derived boundaries; finally, "exclusions" treats ntile tie values as derived
 #' exclusions.
+#' @param sd_scale float, a positive number to scale the estimated KDE variance. 
+#' Defaults to 1.0
 #'
 #' @return A numeric vector with noise added to each prediction
 #' 
@@ -234,7 +236,8 @@ add_noise_kde <- function(model,
                           exclusions = NULL,
                           n_ntiles = NULL, 
                           obs_per_ntile = NULL,
-                          ties_method = "collapse") {
+                          ties_method = "collapse",
+                          sd_scale = 1.0) {
   
   # check args
   if (!is.null(n_ntiles) & !is.null(obs_per_ntile)) {
@@ -264,6 +267,9 @@ add_noise_kde <- function(model,
     )
   }
   
+  stopifnot("`sd_scale` must be a positive number" = {
+    sd_scale > 0
+  })
   
   
   # 1 + 2: extract baseline data and calculate confidential KDE bandwidths
@@ -304,20 +310,21 @@ add_noise_kde <- function(model,
     pred_with_noise <- dplyr::bind_cols(
       pred_ntiles,
       pred_with_noise = purrr::map2_dbl(.x = pred_ntiles$pred, 
-                                        .y = pred_ntiles$bandwidth, 
+                                        .y = pred_ntiles$bandwidth * sd_scale, 
                                         .f = ~ rnorm(n = 1, mean = .x, sd = .y))
     ) %>%
       dplyr::pull(pred_with_noise)
-    
   } else {
     
     pred_with_noise <- dplyr::bind_cols(
       pred_ntiles,
-      pred_with_noise = purrr::map2_dbl(.x = pred_ntiles$pred, 
-                                        .y = pred_ntiles$bandwidth, 
-                                        .f = ~ dplyr::if_else(condition = .x %in% exclusions, 
-                                                              true = as.numeric(.x), 
-                                                              false = rnorm(n = 1, mean = .x, sd = .y)))
+      pred_with_noise = purrr::map2_dbl(
+        .x = pred_ntiles$pred, 
+        .y = pred_ntiles$bandwidth * sd_scale, 
+        .f = ~ dplyr::if_else(condition = .x %in% exclusions, 
+                              true = as.numeric(.x), 
+                              false = rnorm(n = 1, mean = .x, sd = .y))
+      )
     ) %>%
       dplyr::pull(pred_with_noise)
     

--- a/man/add_noise_kde.Rd
+++ b/man/add_noise_kde.Rd
@@ -15,7 +15,8 @@ add_noise_kde(
   exclusions = NULL,
   n_ntiles = NULL,
   obs_per_ntile = NULL,
-  ties_method = "collapse"
+  ties_method = "collapse",
+  sd_scale = 1
 )
 }
 \arguments{
@@ -36,7 +37,7 @@ add_noise_kde(
 \item{n_ntiles}{The number of ntiles}
 
 \item{obs_per_ntile}{A numeric for the minimum number of observations to be
-in an ntile. Cannot be used in conjunction with the \code{ntiles} argument.}
+in an ntile. Cannot be used in conjunction with the \code{n_ntiles} argument.}
 
 \item{ties_method}{The ntiles approach to adding noise requires a one-to-one
 mapping from model-generated values to ntiles in the original data. The
@@ -45,6 +46,9 @@ ntiles lack unique bounds. "collapse" collapses ntile breaks to preserve the
 one-to-one relationship; "random" adds a small random perturbation to the
 derived boundaries; finally, "exclusions" treats ntile tie values as derived
 exclusions.}
+
+\item{sd_scale}{float, a positive number to scale the estimated KDE variance.
+Defaults to 1.0}
 }
 \value{
 A numeric vector with noise added to each prediction

--- a/tests/testthat/test-add_noise_kde.R
+++ b/tests/testthat/test-add_noise_kde.R
@@ -125,6 +125,20 @@ test_that("add_noise_kde error checking", {
     )
   )
   
+  # invalid sd_scale
+  expect_error(
+    add_noise_kde(
+      model = model,
+      new_data = new_data,
+      conf_model_data = conf_model_data,
+      outcome_var = outcome_var,
+      col_schema = col_schema,
+      pred = pred,
+      n_ntiles = 2,
+      sd_scale = -1
+    )
+  )
+  
 })
 
 
@@ -183,5 +197,41 @@ test_that("add_noise_kde basic reproducibility with obs_per_ntile rounding", {
   )
   
   expect_true(all(sample1 == sample2))
+  
+})
+
+
+test_that("add_noise_kde sd_scale", {
+  
+  test_preds <- rep(pred, 100)
+  
+  set.seed(1)
+  sample1 <- add_noise_kde(
+    model = model,
+    new_data = new_data,
+    conf_model_data = conf_model_data,
+    outcome_var = outcome_var,
+    col_schema = col_schema,
+    pred = test_preds,
+    n_ntiles = n_ntiles,
+    sd_scale = 1
+  )
+  
+  set.seed(1)
+  sample2 <- add_noise_kde(
+    model = model,
+    new_data = new_data,
+    conf_model_data = conf_model_data,
+    outcome_var = outcome_var,
+    col_schema = col_schema,
+    pred = test_preds,
+    n_ntiles = n_ntiles,
+    sd_scale = 10
+  )
+  
+  # expect ratio in empirical SDs to be `sd_scale`
+  expect_equal(
+    sd(sample2 - test_preds) / sd(sample1 - test_preds), 10.0
+  )
   
 })


### PR DESCRIPTION
Adds `sd_scale` parameter to `add_noise_kde()`

Example usage: 

```
# increase SD by 3 times KDE output
noise_ob <- noise(
    add_noise = TRUE,
    mode = "regression",
    noise_func = add_noise_kde,
    n_ntiles = 10,
    sd_scale = 3
  )
```

```
── R CMD check results ───── tidysynthesis 0.1.0 ────
Duration: 39.2s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

R CMD check succeeded
```


```
> covr::package_coverage()
tidysynthesis Coverage: 100.00%
```

