### PR TITLE
add current messages to expect_error() calls

### DIFF
--- a/tests/testthat/test-add_noise_cat_unif.R
+++ b/tests/testthat/test-add_noise_cat_unif.R
@@ -100,7 +100,9 @@ test_that("add_noise_cat_unif error handling", {
       outcome_var = outcome_var,
       col_schema = col_schema,
       pred = pred
-    )
+    ),
+    regexp = "argument \"unif_prop\" is missing, with no default",
+    fixed = TRUE
   )
   
   # unif_prop must be between 0 and 1
@@ -113,7 +115,9 @@ test_that("add_noise_cat_unif error handling", {
       col_schema = col_schema,
       pred = pred,
       unif_prop = 2
-    )
+    ),
+    regexp = "unif_prop >= 0 & unif_prop <= 1 is not TRUE",
+    fixed = TRUE
   )
   
   # resample_props names must be correct
@@ -127,7 +131,9 @@ test_that("add_noise_cat_unif error handling", {
       pred = pred,
       unif_prop = .5,
       resample_props = c("notalevel" = 1)
-    )
+    ),
+    regexp = "names(resample_props) %in% resample_levels is not TRUE",
+    fixed = TRUE
   )
   
   # observed_levels drops a level specified in resample_props
@@ -144,7 +150,9 @@ test_that("add_noise_cat_unif error handling", {
         observed_levels = TRUE,
         resample_props = c("3" = 1, "4" = 0, "5" = 1)
       ) 
-    )
+    ),
+    regexp = "names(resample_props) %in% resample_levels are not all TRUE",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-add_noise_disc_gaussian.R
+++ b/tests/testthat/test-add_noise_disc_gaussian.R
@@ -94,7 +94,9 @@ test_that("add_noise_disc_gaussian error handling", {
       outcome_var = outcome_var,
       col_schema = col_schema,
       pred = pred
-    )
+    ),
+    regexp = "Must specify either `variance` or both `rho` and `sensitivity`",
+    fixed = TRUE
   )
   
   # too many variance parameters specified
@@ -108,7 +110,9 @@ test_that("add_noise_disc_gaussian error handling", {
       pred = pred,
       variance = 1,
       rho = 2
-    )
+    ),
+    regexp = "If using variance, rho and sensitivity cannot be specified.",
+    fixed = TRUE
   )
   
   # not enough variance parameters specified
@@ -121,7 +125,9 @@ test_that("add_noise_disc_gaussian error handling", {
       col_schema = col_schema,
       pred = pred,
       rho = 2
-    )
+    ),
+    regexp = "Must specify either `variance` or both `rho` and `sensitivity`",
+    fixed = TRUE
   )
   
   # incorrect increment 

--- a/tests/testthat/test-add_noise_disc_laplace.R
+++ b/tests/testthat/test-add_noise_disc_laplace.R
@@ -53,7 +53,7 @@ test_that("add_noise_disc_laplace reproduces with either direct var or eDP", {
     pred = pred,
     variance = test_var
   )
-  
+
   set.seed(1)
   noisy_preds2 <- add_noise_disc_laplace(
     model = model,
@@ -100,7 +100,8 @@ test_that("add_noise_disc_laplace error handling", {
       outcome_var = outcome_var,
       col_schema = col_schema,
       pred = pred
-    )
+    ),
+    regexp = "Must specify either `variance` or both `epsilon` and `sensitivity`."
   )
   
   # too many variance parameters specified
@@ -114,7 +115,8 @@ test_that("add_noise_disc_laplace error handling", {
       pred = pred,
       variance = 1,
       epsilon = 2
-    )
+    ),
+    regexp = "If using variance, epsilon and sensitivity cannot be specified."
   )
   
   # not enough variance parameters specified
@@ -127,7 +129,8 @@ test_that("add_noise_disc_laplace error handling", {
       col_schema = col_schema,
       pred = pred,
       epsilon = 2
-    )
+    ),
+    regexp = "Must specify either `variance` or both `epsilon` and `sensitivity`."
   )
   
   # incorrect increment 
@@ -141,7 +144,8 @@ test_that("add_noise_disc_laplace error handling", {
       pred = pred,
       variance = 1,
       increment = 0
-    )
+    ),
+    regexp = "add_noise_disc_laplace increment must be greater than 0."
   )
   
 })

--- a/tests/testthat/test-add_noise_gaussian.R
+++ b/tests/testthat/test-add_noise_gaussian.R
@@ -75,7 +75,9 @@ test_that("add_noise_gaussian error handling", {
       outcome_var = outcome_var,
       col_schema = col_schema,
       pred = pred
-    )
+    ),
+    regexp = "Must specify either `variance` or both `rho` and `sensitivity`.",
+    fixed = TRUE
   )
   
   # too many variance parameters specified
@@ -89,7 +91,9 @@ test_that("add_noise_gaussian error handling", {
       pred = pred,
       variance = 1,
       rho = 2
-    )
+    ),
+    regexp = "Cannot use non-null variance with non-null rho or sensitivity.",
+    fixed = TRUE
   )
   
   # not enough variance parameters specified
@@ -102,7 +106,9 @@ test_that("add_noise_gaussian error handling", {
       col_schema = col_schema,
       pred = pred,
       rho = 2
-    )
+    ),
+    regexp = "Must specify either `variance` or both `rho` and `sensitivity`.",
+    fixed = TRUE
   )
-  
+
 })

--- a/tests/testthat/test-add_noise_kde.R
+++ b/tests/testthat/test-add_noise_kde.R
@@ -95,7 +95,9 @@ test_that("add_noise_kde error checking", {
       pred = pred,
       n_ntiles = NULL,
       obs_per_ntile = NULL
-    )
+    ),
+    regexp = "`n_ntiles` and `obs_per_ntile` are both NULL",
+    fixed = TRUE
   )
   
   expect_error(
@@ -108,7 +110,9 @@ test_that("add_noise_kde error checking", {
       pred = pred,
       n_ntiles = 2,
       obs_per_ntile = 2
-    )
+    ),
+    regexp = "`n_ntiles` and `obs_per_ntile` cannot be set together",
+    fixed = TRUE
   )
   
   # invalid ties method
@@ -122,7 +126,9 @@ test_that("add_noise_kde error checking", {
       pred = pred,
       n_ntiles = 2,
       ties_method = "invalid"
-    )
+    ),
+    regexp = "`ties_method` argument must be one of: collapse, exclusions, random",
+    fixed = TRUE
   )
   
   # invalid sd_scale
@@ -136,7 +142,9 @@ test_that("add_noise_kde error checking", {
       pred = pred,
       n_ntiles = 2,
       sd_scale = -1
-    )
+    ),
+    regexp = "`sd_scale` must be a positive number",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-add_noise_laplace.R
+++ b/tests/testthat/test-add_noise_laplace.R
@@ -75,7 +75,8 @@ test_that("add_noise_laplace error handling", {
       outcome_var = outcome_var,
       col_schema = col_schema,
       pred = pred
-    )
+    ),
+    regexp = "Must specify either `variance` or both `epsilon` and `sensitivity`."
   )
   
   # too many variance parameters specified
@@ -89,7 +90,9 @@ test_that("add_noise_laplace error handling", {
       pred = pred,
       variance = 1,
       epsilon = 2
-    )
+    ),
+    regexp = "Cannot use non-null variance with non-null epsilon or sensitivity.",
+    fixed = TRUE
   )
   
   # not enough variance parameters specified
@@ -102,7 +105,8 @@ test_that("add_noise_laplace error handling", {
       col_schema = col_schema,
       pred = pred,
       epsilon = 2
-    )
+    ),
+    regexp = "Must specify either `variance` or both `epsilon` and `sensitivity`.",
+    fixed = TRUE
   )
-  
 })

--- a/tests/testthat/test-constraints.R
+++ b/tests/testthat/test-constraints.R
@@ -59,11 +59,21 @@ constraints_list_cat <- list(
 test_that("constraints() input errors work ", {
 
   # schema should be a schema
-  expect_error(constraints(schema = 1))
+  expect_error(
+    constraints(schema = 1),
+    regexp = "`schema` must be a schema object",
+    fixed = TRUE
+  )
 
   # numeric constraints should be a data.frame
-  expect_error(constraints(schema = schema, constraints_df_num = 1))
-  
+  expect_error(
+    constraints(
+      schema = schema, 
+      constraints_df_num = 1
+    ),
+    regexp = "`constraints_df_num` must be a data.frame if supplied",
+    fixed = TRUE
+  )
   # numeric constraints should be a properly formatted data.frame
   expect_error(
     constraints(
@@ -74,11 +84,17 @@ test_that("constraints() input errors work ", {
             c("var", "min", "max")
           )
         )
-    )
+    ),
+    regexp = "constraints_df_num missing required column(s): conditions",
+    fixed = TRUE
   )
   
   # categorical constraints should be a data.frame
-  expect_error(constraints(schema = schema, constraints_df_cat = 1))
+  expect_error(
+    constraints(schema = schema, constraints_df_cat = 1),
+    regexp = "`constraints_df_cat` must be a data.frame if supplied",
+    fixed = TRUE
+  )
   
   # numeric constraints should be a properly formatted data.frame
   expect_error(
@@ -90,7 +106,9 @@ test_that("constraints() input errors work ", {
             c("var", "allowed", "forbidden")
           )
         )
-    )
+    ),
+    regexp = "constraints_df_cat missing required column(s): conditions",
+    fixed = TRUE
   )
   
   # max_z_num should be a non-negative integer
@@ -99,7 +117,9 @@ test_that("constraints() input errors work ", {
       schema = schema, 
       constraints_df_num = constraints_df_num, 
       max_z_num = -1
-    )
+    ),
+    regexp = "`max_z_num` values must be non-negative",
+    fixed = TRUE
   )
   
   expect_error(
@@ -107,7 +127,9 @@ test_that("constraints() input errors work ", {
       schema = schema, 
       constraints_df_num = constraints_df_num, 
       max_z_num = 1.5
-    )
+    ),
+    regexp = "`max_z_num` values must be integers",
+    fixed = TRUE
   )
   
   # max_z_cat should be a non-negative integer
@@ -116,7 +138,9 @@ test_that("constraints() input errors work ", {
       schema = schema, 
       constraints_df_cat = constraints_df_cat, 
       max_z_num = -1
-    )
+    ),
+    regexp = "`max_z_num` values must be non-negative",
+    fixed = TRUE
   )
   
   expect_error(
@@ -124,7 +148,9 @@ test_that("constraints() input errors work ", {
       schema = schema, 
       constraints_df_cat = constraints_df_cat, 
       max_z_num = 1.5
-    )
+    ),
+    regexp = "`max_z_num` values must be integers",
+    fixed = TRUE
   )
 
 })
@@ -275,7 +301,9 @@ test_that("update_constraints invalid kwargs", {
         start_data = start_data, 
       ), 
       invalid_kwarg = constraints_df_cat
-    )
+    ),
+    regexp = "Invalid update_constraints argument: invalid_kwarg",
+    fixed = TRUE
   )
   
 })
@@ -321,17 +349,25 @@ test_that("print.constraints", {
 test_that("validate_constraints variable name checking", {
   
   # expect invalid variable names to raise error
-  expect_error({
-    rmap <- roadmap(conf_data = data, start_data = start_data)
-    rmap$constraints$constraints_num <- list("invalid" = constraints_df_num)
-    validate_constraints(rmap)
-  })
+  expect_error(
+    {
+      rmap <- roadmap(conf_data = data, start_data = start_data)
+      rmap$constraints$constraints_num <- list("invalid" = constraints_df_num)
+      validate_constraints(rmap)
+    },
+    regexp = "Numeric constraint variable(s) not set to be synthesized: invalid",
+    fixed = TRUE
+  )
   
-  expect_error({
-    rmap <- roadmap(conf_data = data, start_data = start_data)
-    rmap$constraints$constraints_cat <- list("invalid" = constraints_df_cat)
-    validate_constraints(rmap)
-  })
+  expect_error(
+    {
+      rmap <- roadmap(conf_data = data, start_data = start_data)
+      rmap$constraints$constraints_cat <- list("invalid" = constraints_df_cat)
+      validate_constraints(rmap)
+    },
+    regexp = "Categorical constraint variable(s) not set to be synthesized: invalid",
+    fixed = TRUE
+  )
   
 })
 

--- a/tests/testthat/test-construct_extractors.R
+++ b/tests/testthat/test-construct_extractors.R
@@ -28,14 +28,20 @@ test_that("input errors work correctly", {
     construct_extractors(
       roadmap = df, 
       default_extractor = parsnip::extract_fit_engine, 
-      custom_extractors = NULL)
+      custom_extractors = NULL
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   expect_error(
     construct_extractors(
       roadmap = roadmap, 
       default_extractor = parsnip::extract_fit_engine, 
-      custom_extractors = list("table" = "table"))
+      custom_extractors = list("table" = "table")
+    ),
+    regexp = "subscript out of bounds",
+    fixed = TRUE
   )
 
 })

--- a/tests/testthat/test-construct_models.R
+++ b/tests/testthat/test-construct_models.R
@@ -31,14 +31,18 @@ test_that("input errors work correctly", {
     construct_models(
       roadmap = "apple", 
       default_regression_model = rpart_mod
-    )
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   # must specify models
   expect_error(
     construct_models(
       roadmap = roadmap
-    )
+    ),
+    regexp = "No model(s) specified",
+    fixed = TRUE
   )
   
   # default model must be a model_spec object
@@ -46,14 +50,18 @@ test_that("input errors work correctly", {
     construct_models(
       roadmap = roadmap, 
       default_regression_model = "banana"
-    )
+    ),
+    regexp = "Default regression model(s) has incorrect type",
+    fixed = TRUE
   )
   
   expect_error(
     construct_models(
       roadmap = roadmap, 
-      default_classification_model = "banana"
-    )
+      default_classification_model = "banana",
+    ),
+    regexp = "Default classification model(s) has incorrect type",
+    fixed = TRUE
   )
   
   # custom model must be a list of model_spec objects
@@ -61,7 +69,9 @@ test_that("input errors work correctly", {
     construct_models(
       roadmap = roadmap, 
       custom_model = "apple"
-    )
+    ),
+    regexp = "Custom model(s) list missing variable without model(s) specification: colorcutpricetable",
+    fixed = TRUE
   )
   
   # custom model must be properly specified
@@ -72,7 +82,9 @@ test_that("input errors work correctly", {
         list("vars" = c("not", "in", "visit_sequence"), 
              "model" = rpart_mod)
       )
-    )
+    ),
+    regexp = "Custom model(s) list has variables not in visit_sequence: not, in, visit_sequence",
+    fixed = TRUE
   )
   
   # duplicate custom specifications

--- a/tests/testthat/test-construct_noise.R
+++ b/tests/testthat/test-construct_noise.R
@@ -30,27 +30,37 @@ test_that("Unspecified noise raises a warning, not an error", {
 test_that("input errors work correctly", {
   
   # type checking
-  expect_error(construct_noise(roadmap = "no"))
-  
   expect_error(
-    construct_noise(
-      roadmap = roadmap,
-      default_regression_noise = "notanoise"
-    )
+    construct_noise(roadmap = "no"),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   expect_error(
     construct_noise(
       roadmap = roadmap,
-      default_classification_noise = "notanoise"
-    )
+      default_regression_noise = "notnoise"
+    ),
+    regexp = "Default regression noise(s) has incorrect type",
+    fixed = TRUE
+  )
+  
+  expect_error(
+    construct_noise(
+      roadmap = roadmap,
+      default_classification_noise = "notnoise"
+    ),
+    regexp = "Default classification noise(s) has incorrect type",
+    fixed = TRUE
   )
   
   expect_error(
     construct_noise(
       roadmap = roadmap,
       custom_noise = "notnoises"
-    )
+    ),
+    regexp = "subscript out of bounds",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-construct_recipes.R
+++ b/tests/testthat/test-construct_recipes.R
@@ -206,8 +206,8 @@ test_that("try to break the custom recipes", {
       roadmap = roadmap, 
       custom_steps = too_few_vars
     ),
-    regexp = "\033[1m\033[22m\033[36mℹ\033[39m In index: 1.\n\033[36mℹ\033[39m With name: price.\n\033[1mCaused by error in `pluck_raw()`:\033[22m\n\033[33m!\033[39m Can't pluck from a function at level 1.",
-    fixed = TRUE
+    regexp = "Can't pluck from a function at level 1.",
+    fixed = FALSE
   )
   
   # incorrect variables
@@ -221,8 +221,8 @@ test_that("try to break the custom recipes", {
       roadmap = roadmap, 
       custom_steps = incorrect_vars
     ),
-    regexp = "\033[1m\033[22m\033[36mℹ\033[39m In index: 1.\n\033[36mℹ\033[39m With name: price.\n\033[1mCaused by error in `pluck_raw()`:\033[22m\n\033[33m!\033[39m Can't pluck from a function at level 1.",
-    fixed = TRUE
+    regexp = "Can't pluck from a function at level 1.",
+    fixed = FALSE
   )
   
 })

--- a/tests/testthat/test-construct_recipes.R
+++ b/tests/testthat/test-construct_recipes.R
@@ -45,7 +45,9 @@ test_that("input errors work correctly", {
     construct_recipes(
       roadmap = "apple", 
       default_regression_steps = step1
-    )
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   # recipes must be a function
@@ -53,14 +55,18 @@ test_that("input errors work correctly", {
     construct_recipes(
       roadmap = roadmap, 
       default_regression_steps = "banana"
-    )
+    ),
+    regexp = "Default regression step(s) has incorrect type",
+    fixed = TRUE
   )
   
   expect_error(
     construct_recipes(
       roadmap = roadmap, 
       default_classification_steps = "banana"
-    )
+    ),
+    regexp = "Default classification step(s) has incorrect type",
+    fixed = TRUE
   )
   
   # custom recipes must be a list of functions
@@ -69,7 +75,9 @@ test_that("input errors work correctly", {
       roadmap = roadmap, 
       default_regression_steps = step1,
       custom_steps = "apple"
-    )
+    ),
+    regexp = "subscript out of bounds",
+    fixed = TRUE
   )
   
   # custom recipes must be correctly specified
@@ -80,7 +88,9 @@ test_that("input errors work correctly", {
       default_classification_steps = step1,
       custom_steps = list(list("vars" = c("price", "wrong_var"), 
                                "steps" = step2))
-    )
+    ),
+    regexp = "Custom step(s) list has variables not in visit_sequence: wrong_var",
+    fixed = TRUE
   )
   
   # custom recipes should not have duplicate vars
@@ -93,7 +103,9 @@ test_that("input errors work correctly", {
                                "steps" = step1),
                           list("vars" = c("price"), 
                                "steps" = step2))
-    )
+    ),
+    regexp = "Custom step(s) list has repeated variable names: price",
+    fixed = TRUE
   )
   
 })
@@ -193,7 +205,9 @@ test_that("try to break the custom recipes", {
     construct_recipes(
       roadmap = roadmap, 
       custom_steps = too_few_vars
-    )
+    ),
+    regexp = "\033[1m\033[22m\033[36mℹ\033[39m In index: 1.\n\033[36mℹ\033[39m With name: price.\n\033[1mCaused by error in `pluck_raw()`:\033[22m\n\033[33m!\033[39m Can't pluck from a function at level 1.",
+    fixed = TRUE
   )
   
   # incorrect variables
@@ -206,7 +220,9 @@ test_that("try to break the custom recipes", {
     construct_recipes(
       roadmap = roadmap, 
       custom_steps = incorrect_vars
-    )
+    ),
+    regexp = "\033[1m\033[22m\033[36mℹ\033[39m In index: 1.\n\033[36mℹ\033[39m With name: price.\n\033[1mCaused by error in `pluck_raw()`:\033[22m\n\033[33m!\033[39m Can't pluck from a function at level 1.",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-construct_samplers.R
+++ b/tests/testthat/test-construct_samplers.R
@@ -15,34 +15,46 @@ roadmap <- roadmap(conf_data = df, start_data = df_start)
 test_that("input errors work correctly", {
   
   # type checking
-  expect_error(construct_samplers(roadmap = "no"))
+  expect_error(
+    construct_samplers(roadmap = "no"),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
+  )
   
   # no samplers specified
   expect_error(
     construct_samplers(
       roadmap = roadmap
-    )
+    ),
+    regexp = "No sampler(s) specified",
+    fixed = TRUE
   )
   
   expect_error(
     construct_samplers(
       roadmap = roadmap,
       default_regression_sampler = "notasampler"
-    )
+    ),
+    regexp = "Default regression sampler(s) has incorrect type",
+    fixed = TRUE
   )
   
   expect_error(
     construct_samplers(
       roadmap = roadmap,
       default_classification_sampler = "notasampler"
-    )
+    ),
+    regexp = "Default classification sampler(s) has incorrect type",
+    fixed = TRUE
   )
   
   expect_error(
     construct_samplers(
       roadmap = roadmap,
       custom_samplers = "notsamplers"
-    )
+    ),
+    regexp = "Custom sampler(s) list missing variable without sampler(s) specification: colorcutpricetable",
+    fixed = TRUE
   )
   
   # inclusion checking for missing custom specifications
@@ -52,7 +64,9 @@ test_that("input errors work correctly", {
       custom_samplers = list(
         list("vars" = c("color", "cut"), "sampler" = sample_ranger)
       )
-    )
+    ),
+    regexp = "Custom sampler(s) list missing variable without sampler(s) specification: pricetable",
+    fixed = TRUE
   )
   
   # duplicate custom specifications
@@ -63,7 +77,9 @@ test_that("input errors work correctly", {
         list("vars" = c("color", "cut"), "sampler" = sample_ranger),
         list("vars" = c("price", "table", "color"), "sampler" = sample_ranger)
       )
-    )
+    ),
+    regexp = "Custom sampler(s) list has repeated variable names: color",
+    fixed = TRUE
   )
   
   # including only regression or classification samplers when both are needed
@@ -71,14 +87,18 @@ test_that("input errors work correctly", {
     construct_samplers(
       roadmap = roadmap,
       default_regression_sampler = sample_rpart
-    )
+    ),
+    regexp = "Variables missing sampler(s) specification: color, cut",
+    fixed = TRUE
   )
   
   expect_error(
     construct_samplers(
       roadmap = roadmap,
       default_classification_sampler = sample_rpart
-    )
+    ),
+    regexp = "Variables missing sampler(s) specification: price, table",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-construct_tuners.R
+++ b/tests/testthat/test-construct_tuners.R
@@ -33,21 +33,29 @@ test_that("input errors work correctly", {
       default_regression_tuner = NULL,
       default_classification_tuner = NULL,
       custom_tuners = NULL
-    )
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   expect_error(
     construct_tuners(
       roadmap = df, 
       default_regression_tuner = "notatuner", 
-      custom_tuners = NULL)
+      custom_tuners = NULL
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
   expect_error(
     construct_tuners(
       roadmap = roadmap, 
       default_regression_tuner = default_tuner, 
-      custom_tuners = list("table" = "table"))
+      custom_tuners = list("table" = "table")
+    ),
+    regexp = "subscript out of bounds",
+    fixed = TRUE
   )
   
   # incorrect variable names
@@ -57,7 +65,9 @@ test_that("input errors work correctly", {
       default_regression_tuner = default_tuner, 
       custom_tuners = list(list("vars" = c("color", "notavar"),
                                 "tuner" = default_tuner_alt))
-    )
+    ),
+    regexp = "Custom tuner(s) list has variables not in visit_sequence: notavar",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-convert_level_to_na.R
+++ b/tests/testthat/test-convert_level_to_na.R
@@ -19,9 +19,21 @@ test_that("Convert 'NA' to NA", {
 
 test_that("'NA' already in the data throws an error", {
 
-  expect_error(convert_level_to_na(data = data.frame(x2 = c("1", "2", NA))))
-  expect_error(convert_level_to_na(data = data.frame(x3 = factor(c("1", "2", NA)))))
-  expect_error(convert_level_to_na(data = data.frame(factor(c("b", NA, "a"), ordered = TRUE))))
+  expect_error(
+    convert_level_to_na(data = data.frame(x2 = c("1", "2", NA))),
+    regexp = "Vector already contains NA; cannot call convert_level_to_NA",
+    fixed = FALSE
+  )
+  expect_error(
+    convert_level_to_na(data = data.frame(x3 = factor(c("1", "2", NA)))),
+    regexp = "Vector already contains NA; cannot call convert_level_to_NA",
+    fixed = FALSE
+  )
+  expect_error(
+    convert_level_to_na(data = data.frame(factor(c("b", NA, "a"), ordered = TRUE))),
+    regexp = "Vector already contains NA; cannot call convert_level_to_NA",
+    fixed = FALSE
+  )
 
 })
 

--- a/tests/testthat/test-convert_na_to_level.R
+++ b/tests/testthat/test-convert_na_to_level.R
@@ -19,8 +19,20 @@ test_that("Convert NA to 'NA'", {
 
 test_that("'NA' already in the data throws an error", {
 
-  expect_error(convert_na_to_level(data = data.frame(x2 = c("1", "2", "NA"))))
-  expect_error(convert_na_to_level(data = data.frame(x3 = factor(c("1", "2", "NA")))))
-  expect_error(convert_na_to_level(data = data.frame(factor(c("b", "NA", "a"), ordered = TRUE))))
+  expect_error(
+    convert_na_to_level(data = data.frame(x2 = c("1", "2", "NA"))),
+    regexp = "Can't convert NA to level 'NA' because level 'NA' already exists",
+    fixed = FALSE
+  )
+  expect_error(
+    convert_na_to_level(data = data.frame(x3 = factor(c("1", "2", "NA")))),
+    regexp = "Can't convert NA to level 'NA' because level 'NA' already exists",
+    fixed = FALSE
+  )
+  expect_error(
+    convert_na_to_level(data = data.frame(factor(c("b", "NA", "a"), ordered = TRUE))),
+    regexp = "Can't convert NA to level 'NA' because level 'NA' already exists",
+    fixed = FALSE
+  )
 
 })

--- a/tests/testthat/test-create_ntiles.R
+++ b/tests/testthat/test-create_ntiles.R
@@ -67,16 +67,24 @@ test_that(".create_ntiles returns expected values with exclusions", {
 # missing values and illegal values
 test_that(".create_ntiles fails with incorrect inputs", {
   expect_error(
-    .create_ntiles(x_bounds = c(1:10, NA, NA), y_ntiles = 1:10, n = 2)$ntiles
+    .create_ntiles(x_bounds = c(1:10, NA, NA), y_ntiles = 1:10, n = 2)$ntiles,
+    regexp = "!any(is.na(x_bounds)) is not TRUE",
+    fixed = TRUE
   )
   expect_error(
-    .create_ntiles(x_bounds = c("a", "b", "c"), y_ntiles = 1:10, n = 2)$ntiles
+    .create_ntiles(x_bounds = c("a", "b", "c"), y_ntiles = 1:10, n = 2)$ntiles,
+    regexp = "is.numeric(x_bounds) is not TRUE",
+    fixed = TRUE
   )
   expect_error(
-    .create_ntiles(x_bounds = 1:10, y_ntiles = c("a", "b", "c"), n = 2)$ntiles
+    .create_ntiles(x_bounds = 1:10, y_ntiles = c("a", "b", "c"), n = 2)$ntiles,
+    regexp = "is.numeric(y_ntiles) is not TRUE",
+    fixed = TRUE
   )
   expect_error(
-    .create_ntiles(x_bounds = seq(1, 10, by = 1), y_ntiles = seq(1, 10, by = 1), n = 20)$ntiles
+    .create_ntiles(x_bounds = seq(1, 10, by = 1), y_ntiles = seq(1, 10, by = 1), n = 20)$ntiles,
+    regexp = "`n` can't exceed the length of the confidential variable",
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-enforce_schema.R
+++ b/tests/testthat/test-enforce_schema.R
@@ -23,7 +23,11 @@ test_that("sum_to_cast_categorical basic functionality", {
   expect_equal(.sum_to_cast_categorical(test_col_lgl, "lgl") %>% class, "logical")
   
   # expect invalid casting with incorrect type
-  expect_error(.sum_to_cast_categorical(test_col, "not_a_dtype_sum"))
+  expect_error(
+    .sum_to_cast_categorical(test_col, "not_a_dtype_sum"),
+    regexp = "Cannot enforce_schema() with unsupported categorical type: not_a_dtype_sum",
+    fixed = TRUE
+  )
   
 })
 
@@ -38,7 +42,11 @@ test_that("sum_to_cast_numeric basic functionality", {
   expect_equal(.sum_to_cast_numeric(acs_conf[["age"]], "dbl") %>% class, "numeric")
   
   # expect invalid casting with incorrect type
-  expect_error(.sum_to_cast_numeric(test_col, "not_a_dtype_sum"))
+  expect_error(
+    .sum_to_cast_numeric(test_col, "not_a_dtype_sum"),
+    regexp = "Cannot enforce_schema() with unsupported numeric type: not_a_dtype_sum",
+    fixed = TRUE
+  )
   
 })
 

--- a/tests/testthat/test-expand_na.R
+++ b/tests/testthat/test-expand_na.R
@@ -26,7 +26,11 @@ test_that("Expanded example_na correctly labels missing and nonmissing values", 
 
 test_that("Variable with name containing '_NA' throws an error", {
 
-  expect_error(expand_na(data = data.frame(x2_NA = c("1", "2", NA))))
+  expect_error(
+    expand_na(data = data.frame(x2_NA = c("1", "2", NA))),
+    regexp = "If using incomplete data, variable names cannot end in '_NA'",
+    fixed = FALSE
+)
 
 })
 

--- a/tests/testthat/test-invert.R
+++ b/tests/testthat/test-invert.R
@@ -24,7 +24,9 @@ test_that("invert.step_BoxCox fails with incorrect lambdas length ", {
   
   expect_error(
     invert(object = adj$steps[[1]], 
-           predictions = tibble::tibble(.pred = adj[["template"]][["y"]]))
+           predictions = tibble::tibble(.pred = adj[["template"]][["y"]])),
+    regexp = "Too many lambdas for invert.step_BoxCox()",
+    fixed = TRUE
   )
   
 })
@@ -103,7 +105,9 @@ test_that("invert.step_YeoJohnson fails with incorrect lambdas length ", {
   
   expect_error(
     invert(object = adj$steps[[1]], 
-           predictions = tibble::tibble(.pred = adj[["template"]][["y"]]))
+           predictions = tibble::tibble(.pred = adj[["template"]][["y"]])),
+    regexp = "Too many lambdas for invert.step_YeoJohnson()",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-noise.R
+++ b/tests/testthat/test-noise.R
@@ -14,23 +14,31 @@ test_that("noise() input tests guard against input error", {
   
   # input type checking
   expect_error(
-    noise(add_noise = "not_logical")
+    noise(add_noise = "not_logical"),
+    regexp = "is.logical(add_noise) is not TRUE",
+    fixed = TRUE
   )
   
   expect_error(
     noise(add_noise = FALSE,
-          mode = "invalid_mode")
+          mode = "notamode"),
+    regexp = "mode %in% c(\"regression\", \"classification\") is not TRUE",
+    fixed = TRUE
   )
   
   expect_error(
     noise(add_noise = TRUE,
           mode = "regression",
-          noise_func = "not_a_function")
+          noise_func = "not_a_function"),
+    regexp = "is.null(noise_func) | is.function(noise_func) is not TRUE",
+    fixed = TRUE
   )
   
   # check for supplied noise_func if add_noise = TRUE
   expect_error(
-    noise(add_noise = TRUE)
+    noise(add_noise = TRUE),
+    regexp = "`add_noise` is TRUE but no `noise_func` specified.",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-presynth.R
+++ b/tests/testthat/test-presynth.R
@@ -72,14 +72,18 @@ test_that("presynth input errors", {
     presynth(
       roadmap = roadmap,
       synth_spec = "not a synth_spec"
-    )
+    ),
+    regexp = "`synth_spec` must be a synth_spec object",
+    fixed = TRUE
   )
   
   expect_error(
     presynth(
       roadmap = "not a roadmap",
       synth_spec = synth_spec
-    )
+    ),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
   )
   
 })
@@ -131,6 +135,10 @@ test_that("variable location by type validation", {
   )
   ps$workflows$built_models$mpg <- dt_class_mod
   
-  expect_error(.validate_presynth(ps))
+  expect_error(
+    .validate_presynth(ps),
+    regexp = "Variable types in visit_sequence do not match model types in synth_algorithms\n  Problem variable(s): mpg",
+    fixed = TRUE
+  )
   
 })

--- a/tests/testthat/test-replicates.R
+++ b/tests/testthat/test-replicates.R
@@ -31,15 +31,47 @@ test_that("replicate total accounting", {
 test_that("replicates input type checking", {
   
   # expect error for incorrect types
-  expect_error(replicates(start_data_replicates = FALSE))
-  expect_error(replicates(start_data_replicates = 1.5))
-  expect_error(replicates(start_data_replicates = -1))
-  expect_error(replicates(start_data_replicates = c(1, 2, 3)))
+  expect_error(
+    replicates(start_data_replicates = FALSE), 
+    regexp = "Argument `start_data_replicates` is not numeric.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(start_data_replicates = 1.5), 
+    regexp = "Argument `start_data_replicates` must be integer-valued.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(start_data_replicates = -1), 
+    regexp = "Argument `start_data_replicates` must be >= 1.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(start_data_replicates = c(1, 2, 3)), 
+    regexp = "Argument `start_data_replicates` must be length 1.",
+    fixed = TRUE
+  )
   
-  expect_error(replicates(model_sample_replicates = FALSE))
-  expect_error(replicates(model_sample_replicates = 1.5))
-  expect_error(replicates(model_sample_replicates = -1))
-  expect_error(replicates(model_sample_replicates = c(1, 2, 3)))
+  expect_error(
+    replicates(model_sample_replicates = FALSE), 
+    regexp = "Argument `model_sample_replicates` is not numeric.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(model_sample_replicates = 1.5), 
+    regexp = "Argument `model_sample_replicates` must be integer-valued.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(model_sample_replicates = -1), 
+    regexp = "Argument `model_sample_replicates` must be >= 1.",
+    fixed = TRUE
+  )
+  expect_error(
+    replicates(model_sample_replicates = c(1, 2, 3)), 
+    regexp = "Argument `model_sample_replicates` must be length 1.",
+    fixed = TRUE
+  )
   
 })
 

--- a/tests/testthat/test-roadmap.R
+++ b/tests/testthat/test-roadmap.R
@@ -6,34 +6,52 @@ roadmap <- roadmap(conf_data = data, start_data = start_data)
 test_that("roadmap() input errors work ", {
   
   # conf_data must be a data frame
-  expect_error(roadmap(conf_data = data, start_data = 1))
+  expect_error(
+    roadmap(conf_data = data, start_data = 1), 
+    regexp = "`start_data` must be a data.frame",
+    fixed = TRUE
+  )
   
   # start_data must be a data frame
-  expect_error(roadmap(conf_data = 1, start_data = start_data))
+  expect_error(
+    roadmap(conf_data = 1, start_data = start_data), 
+    regexp = "`conf_data` must be a data.frame",
+    fixed = TRUE
+  )
   
   # start_method must be a start_method object
   expect_error(
-    roadmap(conf_data = data, start_data = start_data, start_method = 1)
+    roadmap(conf_data = data, start_data = start_data, start_method = 1), 
+    regexp = "`start_method` must be a start_method object",
+    fixed = TRUE
   )
   
   # schema must be a schema object
   expect_error(
-    roadmap(conf_data = data, start_data = start_data, schema = 1)
+    roadmap(conf_data = data, start_data = start_data, schema = 1), 
+    regexp = "`schema` must be a schema object",
+    fixed = TRUE
   )
 
   # visit_sequence must be a visit_sequence object
   expect_error(
-    roadmap(conf_data = data, start_data = start_data, visit_sequence = 1)
+    roadmap(conf_data = data, start_data = start_data, visit_sequence = 1), 
+    regexp = "`visit_sequence` must be a visit_sequence object",
+    fixed = TRUE
   )
   
   # replicates must be a replicates object
   expect_error(
-    roadmap(conf_data = data, start_data = start_data, replicates = 1)
+    roadmap(conf_data = data, start_data = start_data, replicates = 1), 
+    regexp = "`replicates` must be a replcates object",
+    fixed = TRUE
   )
   
   # constraints must be a constraints object
   expect_error(
-    roadmap(conf_data = data, start_data = start_data, constraints = 1)
+    roadmap(conf_data = data, start_data = start_data, constraints = 1), 
+    regexp = "`constraints` must be a constraints object",
+    fixed = TRUE
   )
   
 })
@@ -170,7 +188,9 @@ test_that("roadmap() throws an error for a factor with ordered levels", {
         conf_data = data_factor, 
         start_data = dplyr::select(data_factor, col2) # select the non-ordered-factor column
       )
-    )
+    ), 
+    regexp = "`col_schema` included unsupported dtype(s) ord",
+    fixed = TRUE
   )
   
   expect_no_error(
@@ -210,7 +230,9 @@ test_that("roadmap() throws an error for ordinal variables ", {
         conf_data = example_na,
         start_data = dplyr::select(example_na, age)
       )
-    )
+    ), 
+    regexp = "`col_schema` included unsupported dtype(s) ord",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-sample_glm.R
+++ b/tests/testthat/test-sample_glm.R
@@ -46,7 +46,9 @@ test_that("sample_glm() doesn't work with non-logistic classification models", {
   expect_error(
     sample_glm(model = model_class, 
                new_data = acs_conf[1:3, ], 
-               conf_data = acs_conf)
+               conf_data = acs_conf),
+    regexp = "GLM classification only supported for logistic regression",
+    fixed = TRUE
   )
   
 })
@@ -63,7 +65,9 @@ test_that("sample_glm() doesn't work for non-poisson regression models", {
   expect_error(
     sample1 <- sample_glm(model = model_reg, 
                           new_data = acs_conf[1:3, ], 
-                          conf_data = acs_conf)
+                          conf_data = acs_conf),
+    regexp = "GLM regression only supported for Poisson regression",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-sample_lm.R
+++ b/tests/testthat/test-sample_lm.R
@@ -38,7 +38,9 @@ test_that("sample_lm() doesn't work with classification models", {
   expect_error(
     sample_lm(model = model_class, 
               new_data = acs_conf[1:3, ], 
-              conf_data = acs_conf)
+              conf_data = acs_conf),
+    regexp = "sample_lm only works with regression models",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-schema.R
+++ b/tests/testthat/test-schema.R
@@ -78,47 +78,63 @@ test_that("col_schema argument parsing", {
   
   # expect errors for invalid argument types
   expect_error(
-    schema(conf_data = "not a data.frame", start_data = acs_start)
+    schema(conf_data = "not a data.frame", start_data = acs_start),
+    regexp = "`conf_data` must be a data.frame",
+    fixed = TRUE
   )
   
   expect_error(
-    schema(conf_data = acs_conf, start_data = "not a data.frame")
-  )
-  
-  expect_error(
-    schema(conf_data = acs_conf, 
-           start_data = acs_start, 
-           col_schema = c("not", "a", "list"))
-  )
-  
-  expect_error(
-    schema(conf_data = acs_conf, 
-           start_data = acs_start, 
-           enforce = "not a logical")
+    schema(conf_data = acs_conf, start_data = "not a data.frame"),
+    regexp = "`start_data` must be a data.frame",
+    fixed = TRUE
   )
   
   expect_error(
     schema(conf_data = acs_conf, 
            start_data = acs_start, 
-           coerce_to_factors = "not a logical")
+           col_schema = c("not", "a", "list")),
+    regexp = "`col_schema`, if supplied, must be a list",
+    fixed = TRUE
   )
   
   expect_error(
     schema(conf_data = acs_conf, 
            start_data = acs_start, 
-           coerce_to_doubles = "not a logical")
+           enforce = "not a logical"),
+    regexp = "`enforce` must be logical",
+    fixed = TRUE
   )
   
   expect_error(
     schema(conf_data = acs_conf, 
            start_data = acs_start, 
-           na_factor_to_level = "not a logical")
+           coerce_to_factors = "not a logical"),
+    regexp = "`coerce_to_factors` must be logical",
+    fixed = TRUE
   )
   
   expect_error(
     schema(conf_data = acs_conf, 
            start_data = acs_start, 
-           na_numeric_to_ind = "not a logical")
+           coerce_to_doubles = "not a logical"),
+    regexp = "`coerce_to_doubles` must be logical",
+    fixed = TRUE
+  )
+  
+  expect_error(
+    schema(conf_data = acs_conf, 
+           start_data = acs_start, 
+           na_factor_to_level = "not a logical"),
+    regexp = "`na_factor_to_level` must be logical",
+    fixed = TRUE
+  )
+  
+  expect_error(
+    schema(conf_data = acs_conf, 
+           start_data = acs_start, 
+           na_numeric_to_ind = "not a logical"),
+    regexp = "`na_numeric_to_ind` must be logical",
+    fixed = TRUE
   )
   
 })
@@ -128,14 +144,20 @@ test_that("col_schema argument parsing", {
 test_that("validate_schema expected errors", {
   
   # error if input is not a roadmap
-  expect_error(validate_schema("not_a_roadmap"))
+  expect_error(
+    validate_schema("not_a_roadmap"),
+    regexp = "`roadmap` must be a roadmap object",
+    fixed = TRUE
+)
   
   # error if columns from col_schema not in conf_data
   expect_error(
     validate_schema(
       acs_roadmap %>%
         update_schema(col_schema = list("not_a_column" = list("dtype" = "dbl")))
-    )
+    ),
+    regexp = "`col_schema` included unknown name(s) not_a_column",
+    fixed = TRUE
   )
   
   # error if unsupported dtype provided
@@ -143,7 +165,9 @@ test_that("validate_schema expected errors", {
     validate_schema(
       acs_roadmap %>%
         update_schema(col_schema = list("gq" = list("dtype" = "notatype")))
-    )
+    ),
+    regexp = "`col_schema` included unsupported dtype(s) notatype",
+    fixed = TRUE
   )
   
   # error if unsupported col_schema fields provided
@@ -151,7 +175,9 @@ test_that("validate_schema expected errors", {
     validate_schema(
       acs_roadmap %>%
         update_schema(col_schema = list("gq" = list("notafield" = "dbl")))
-    )
+    ),
+    regexp = "Invalid `col_schema` field names for variable(s) gq",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-start_method.R
+++ b/tests/testthat/test-start_method.R
@@ -37,18 +37,25 @@ test_that("validate_start_method", {
   
   # expect error if wrong start_method type
   expect_error( {
-    acs_roadmap <- roadmap(conf_data = acs_conf_nw, 
-                           start_data = acs_start_nw)
-    acs_roadmap[["start_method"]] <- "wrong"
-    validate_start_method(acs_roadmap)
-  })
+      acs_roadmap <- roadmap(conf_data = acs_conf_nw, 
+                            start_data = acs_start_nw)
+      acs_roadmap[["start_method"]] <- "wrong"
+      validate_start_method(acs_roadmap)
+    },
+    regexp = "`start_method` must be a start_method object",
+    fixed = TRUE
+  )
   
   # expect error if wrong keyword arguments provided
   expect_error(
-    roadmap(conf_data = acs_conf_nw, 
-            start_data = acs_start_nw) %>%
-      update_start_method(not_an_arg = 123) %>%
-      validate_start_method()
+    {
+      roadmap(conf_data = acs_conf_nw, 
+              start_data = acs_start_nw) %>%
+        update_start_method(not_an_arg = 123) %>%
+        validate_start_method()
+    },
+    regexp = "Keyword arguments not aligned with provided start_method function",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-start_resample.R
+++ b/tests/testthat/test-start_resample.R
@@ -51,14 +51,18 @@ test_that("start_resample error handling", {
     start_resample(acs_start_nw, 
                    n = 100,
                    inv_noise_scale = 0,
-                   support = "all")
+                   support = "all"),
+    regexp = "inv_noise_scale > 0 is not TRUE",
+    fixed = TRUE
   )
   
   expect_error(
     start_resample(acs_start_nw, 
                    n = 100,
                    inv_noise_scale = NULL,
-                   support = "all")
+                   support = "all"),
+    regexp = "Cannot resample from complete support with unspecified inv_noise_scale.",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-synth_component_utils.R
+++ b/tests/testthat/test-synth_component_utils.R
@@ -63,45 +63,59 @@ test_that("validate_custom_components works as expected", {
       list(list("vars" = c("a", "b"), "model" = dt_reg_mod),
            "not_a_list"), 
       "model"
-    )
-    
+    ),
+    regexp = "Some custom model elements are not lists.",
+    fixed = TRUE
   )
+
   # error when providing incorrect list names
   expect_error(
     .validate_custom_components(
       list(list("notvars" = c("a", "b"), "model" = dt_reg_mod)), "model"
-    )
+    ),
+    regexp = "Some custom model elements are missing the two required \n         sublist names, 'vars' and 'model'",
+    fixed = TRUE
   )
   
   expect_error(
     .validate_custom_components(
       list(list("vars" = c("a", "b"), "notmodel" = dt_reg_mod)), "model"
-    )
+    ),
+    regexp = "Some custom model elements are missing the two required \n         sublist names, 'vars' and 'model'",
+    fixed = TRUE
   )
   
   expect_error(
     .validate_custom_components(
       list(list("vars" = c("a", "b"), "model" = dt_reg_mod, "a" = 1)), "model"
-    )
+    ),
+    regexp = "Some custom model elements are missing the two required \n         sublist names, 'vars' and 'model'",
+    fixed = TRUE
   )
   
   # error when providing incorrect types
   expect_error(
     .validate_custom_components(
       list(list("vars" = c(1, 2), "model" = dt_reg_mod)), "model"
-    )
+    ),
+    regexp = "Some custom model variable names are not strings.",
+    fixed = TRUE
   )
   
   expect_error(
     .validate_custom_components(
       list(list("vars" = c("a", "b"), "model" = "not a model")), "model"
-    )
+    ),
+    regexp = "Some custom model elements have incorrect type.",
+    fixed = TRUE
   )
   
   expect_error(
     .validate_custom_components(
       list(list("vars" = c("a", "b"), "model" = dt_reg_mod)), "tuner"
-    )
+    ),
+    regexp = "Some custom tuner elements are missing the two required \n         sublist names, 'vars' and 'tuner'",
+    fixed = TRUE
   )
   
 })
@@ -123,8 +137,16 @@ test_that(".map_model_to_default_sampler", {
   )
   
   # type checking
-  expect_error(.map_model_to_default_sampler("not a model"))
-  expect_error(.map_model_to_default_sampler(parsnip::boost_tree()))
+  expect_error(
+    .map_model_to_default_sampler("not a model"),
+    regexp = ".is_model(model) is not TRUE",
+    fixed = TRUE
+  )
+  expect_error(
+    .map_model_to_default_sampler(parsnip::boost_tree()),
+    regexp = "Unrecognized engine: xgboost. Please either supply\n         a specific sampler or use a recognized engine:rpart, ranger, lm, glm",
+    fixed = TRUE
+  )
   
 })
 

--- a/tests/testthat/test-synth_spec.R
+++ b/tests/testthat/test-synth_spec.R
@@ -56,55 +56,81 @@ test_that("synth_spec() fails with improper inputs", {
   
   # default input type checking
   expect_error(
-    synth_spec(default_regression_model = "notamodel")
+    synth_spec(default_regression_model = "notamodel"),
+    regexp = "`default_regression_model` must be a parsnip model_spec, \n    if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_classification_model = "notamodel")
+    synth_spec(default_classification_model = "notamodel"),
+    regexp = "`default_classification_model` must be a parsnip model_spec, \n    if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_regression_step = "notastep")
+    synth_spec(default_regression_step = "notastep"),
+    regexp = "`default_regression_steps` must be a function, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_classification_step = "notastep")
+    synth_spec(default_classification_step = "notastep"),
+    regexp = "`default_classification_steps` must be a function, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_regression_sampler = "notasampler")
+    synth_spec(default_regression_sampler = "notasampler"),
+    regexp = "`default_regression_sampler` must be a function, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_classification_sampler = "notasampler")
+    synth_spec(default_classification_sampler = "notasampler"),
+    regexp = "`default_classification_sampler` must be a function, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_regression_noise = "notnoise")
+    synth_spec(default_regression_noise = "notnoise"),
+    regexp = "`default_regression_noise` must be a noise object, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_classification_noise = "notnoise")
+    synth_spec(default_classification_noise = "notnoise"),
+    regexp = "`default_classification_noise` must be a noise object, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_regression_tuner = "notatuner")
+    synth_spec(default_regression_tuner = "notatuner"),
+    regexp = "`default_regression_tuner` must be a list, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_classification_tuner = "notatuner")
+    synth_spec(default_classification_tuner = "notatuner"),
+    regexp = "`default_classification_tuner` must be a list, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(default_extractor = "notanextractor")
+    synth_spec(default_extractor = "notanextractor"),
+    regexp = "`default extractor` must be a function, if specified",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(invert_transformations = "no")
+    synth_spec(invert_transformations = "no"),
+    regexp = "`invert_transformations` must be logical",
+    fixed = TRUE
   )
   
   expect_error(
-    synth_spec(enforce_na = "no")
+    synth_spec(enforce_na = "no"),
+    regexp = "`enforce_na` must be logical",
+    fixed = TRUE
   )
   
 })
@@ -118,37 +144,59 @@ test_that("update_synth_spec", {
   expect_false(new_ss1[["enforce_na"]])
   
   # invalid argument names
-  expect_error(update_synth_spec(old_ss, not_an_arg = TRUE))
-  expect_error(update_synth_spec(old_ss,
-                                 not_an_arg = TRUE,
-                                 enforce_na = FALSE))
   expect_error(
-    expect_warning(update_synth_spec(old_ss, custom_models = list()))
+    update_synth_spec(old_ss, not_an_arg = TRUE),
+    regexp = "Unexpected argument(s) to update_synth_spec(): not_an_arg",
+    fixed = TRUE
+  )
+  expect_error(
+    update_synth_spec(old_ss,
+                      not_an_arg = TRUE,
+                      enforce_na = FALSE),
+    regexp = "Unexpected argument(s) to update_synth_spec(): not_an_arg",
+    fixed = TRUE
+  )
+  expect_error(
+    expect_warning(update_synth_spec(old_ss, custom_models = list())),
+    regexp = "Unexpected argument(s) to update_synth_spec(): custom_models",
+    fixed = TRUE
   )
   
   # invalid inpupt types
   expect_error(
-    update_synth_spec(old_ss, default_regression_model = "notamodel")
+    update_synth_spec(old_ss, default_regression_model = "notamodel"),
+    regexp = "Default model parameter must be a parsnip model_spec",
+    fixed = TRUE
   )
   
   expect_error(
-    update_synth_spec(old_ss, default_regression_steps = "notastep")
+    update_synth_spec(old_ss, default_regression_steps = "notastep"),
+    regexp = "Default steps parameter must be a function",
+    fixed = TRUE
   )
   
   expect_error(
-    update_synth_spec(old_ss, default_regression_sampler = "notasampler")
+    update_synth_spec(old_ss, default_regression_sampler = "notasampler"),
+    regexp = "Default sampler parameter must be a function",
+    fixed = TRUE
   )
   
   expect_error(
-    update_synth_spec(old_ss, default_regression_noise = "notnoise")
+    update_synth_spec(old_ss, default_regression_noise = "notnoise"),
+    regexp = "Default noise parameter must be a noise object",
+    fixed = TRUE
   )
   
   expect_error(
-    update_synth_spec(old_ss, default_regression_tuner = "notatuner")
+    update_synth_spec(old_ss, default_regression_tuner = "notatuner"),
+    regexp = "Default tuner parameter must be a list",
+    fixed = TRUE
   )
   
   expect_error(
-    update_synth_spec(old_ss, default_regression_extractor = "notanextractor")
+    update_synth_spec(old_ss, default_regression_extractor = "notanextractor"),
+    regexp = "Unexpected argument(s) to update_synth_spec(): default_regression_extractor",
+    fixed = TRUE
   )
   
 })
@@ -172,7 +220,9 @@ test_that("add_custom_models", {
         "invalid" = c("a", "b", "c"),
         "model" = dt_reg_mod
       )
-    )
+    ),
+    regexp = "Some custom model elements are missing the two required \n         sublist names, 'vars' and 'model'",
+    fixed = TRUE
   )
   
 })
@@ -230,7 +280,9 @@ test_that("add_custom_steps", {
         "invalid" = c("a", "b", "c"),
         "steps" = step1
       )
-    )
+    ),
+    regexp = "Some custom model elements are missing the two required \n         sublist names, 'vars' and 'model'",
+    fixed = TRUE
   )
   
 })
@@ -290,7 +342,9 @@ test_that("add_custom_samplers", {
         "invalid" = c("a", "b", "c"),
         "sampler" = sample_rpart
       )
-    )
+    ),
+    regexp = "Some custom sampler elements are missing the two required \n         sublist names, 'vars' and 'sampler'",
+    fixed = TRUE
   )
   
 })
@@ -351,7 +405,9 @@ test_that("add_custom_noises", {
         "invalid" = c("a", "b", "c"),
         "noise" = noise1
       )
-    )
+    ),
+    regexp = "Some custom noise elements are missing the two required \n         sublist names, 'vars' and 'noise'",
+    fixed = TRUE
   )
   
 })
@@ -410,7 +466,9 @@ test_that("add_custom_tuners", {
         "invalid" = c("a", "b", "c"),
         "tuner" = tuner1
       )
-    )
+    ),
+    regexp = "Some custom tuner elements are missing the two required \n         sublist names, 'vars' and 'tuner'",
+    fixed = TRUE
   )
   
 })
@@ -471,7 +529,9 @@ test_that("add_custom_extractors", {
         "invalid" = c("a", "b", "c"),
         "extractor" = extractor1
       )
-    )
+    ),
+    regexp = "Some custom extractor elements are missing the two required \n         sublist names, 'vars' and 'extractor'",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-synthesize-factor-first.R
+++ b/tests/testthat/test-synthesize-factor-first.R
@@ -90,6 +90,10 @@ test_that("failure when obs_per_ntile > start_data", {
     )
   )
   
-  expect_error(synth2 <- synthesize(presynth_noise_too_big))
+  expect_error(
+    synthesize(presynth_noise_too_big),
+    regexp = "unused argument (noise_params = list(0, 334))",
+    fixed = TRUE
+  )
   
 })

--- a/tests/testthat/test-synthesize_j.R
+++ b/tests/testthat/test-synthesize_j.R
@@ -33,17 +33,19 @@ test_that("synthesize_j() throws error with no sampler specified ", {
   mtcars_rec <- recipes::recipe(mpg ~ cyl + disp + hp, data = mtcars)
   
   expect_error(
-    jth_synth <- synthesize_j(conf_data = mtcars,
-                              synth_data = dplyr::select(mtcars, cyl, disp, hp),
-                              col_schema = list(dtype = "dbl", na_prop = 0),
-                              recipe = mtcars_rec,
-                              sampler = NULL,
-                              noise = default_noise,
-                              tuner = NULL,
-                              extractor = NULL,
-                              constraints = NULL,
-                              model = rpart_mod,
-                              invert_transformations = TRUE)
+    synthesize_j(conf_data = mtcars,
+                 synth_data = dplyr::select(mtcars, cyl, disp, hp),
+                 col_schema = list(dtype = "dbl", na_prop = 0),
+                 recipe = mtcars_rec,
+                 sampler = NULL,
+                 noise = default_noise,
+                 tuner = NULL,
+                 extractor = NULL,
+                 constraints = NULL,
+                 model = rpart_mod,
+                 invert_transformations = TRUE),
+    regexp = "Missing sampler object in generate_predictions().",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-tune_synthesis.R
+++ b/tests/testthat/test-tune_synthesis.R
@@ -138,18 +138,24 @@ test_that("Invalid inputs throw errors as expected", {
 
   expect_error(
     tune_synthesis(list("not_a_presynth"), 
-                   postproc_f_null)
+                   postproc_f_null),
+    regexp = "`presynths` elements must be presynth objects",
+    fixed = TRUE
   )
   
   expect_error(
     tune_synthesis(list(presynth1), 
-                   function(z) { })
+                   function(z) { }),
+    regexp = "`postprocessing_func` must have required arguments: synth_id, synth_name, \n    and postsynth",
+    fixed = TRUE
   )
   
   expect_error(
     tune_synthesis(list(presynth1), 
                    postprof_f_null, 
-                   metadata_func = function(z) {})
+                   metadata_func = function(z) {}),
+    regexp = "object 'postprof_f_null' not found",
+    fixed = TRUE
   )
     
 })

--- a/tests/testthat/test-visit_sequence.R
+++ b/tests/testthat/test-visit_sequence.R
@@ -38,7 +38,9 @@ test_that("validate_visit_sequence errors", {
   expect_error(
     roadmap(conf_data = acs_conf_nw, start_data = acs_start) %>%
       update_visit_sequence(weight_var = wgt) %>%
-      validate_visit_sequence()
+      validate_visit_sequence(),
+    regexp = "Cannot synthesize weight_var if weight_var is in start_data",
+    fixed = TRUE
   )
   
   # error if visit_sequence does not contain all synth_vars
@@ -50,7 +52,9 @@ test_that("validate_visit_sequence errors", {
                           start_data = acs_start_nw)
         )
       ) %>%
-      validate_visit_sequence()
+      validate_visit_sequence(),
+    regexp = "Variables from the visit sequence must be in conf_data and not in start_data\n  Problem variable(s): wgt",
+    fixed = TRUE
   )
   
 })
@@ -82,7 +86,9 @@ test_that("visit_sequence respects NA variable ordering", {
     add_sequence_manual(inctot, inctot_NA)
   
   expect_error(
-    validate_visit_sequence(roadmap)
+    validate_visit_sequence(roadmap),
+    regexp = "_NA vars must come before their corresponding variables. \n Issues with inctot_NA and inctot",
+    fixed = TRUE
   )
   
 })

--- a/tests/testthat/test-visit_sequence_api.R
+++ b/tests/testthat/test-visit_sequence_api.R
@@ -141,7 +141,9 @@ test_that("visit_sequence correlation order", {
         dplyr::where(is.numeric), 
         method = "correlation", 
         cor_var = "not_in_conf_data"
-      )
+      ),
+    regexp = "`cor_var` isn't in conf_data",
+    fixed = TRUE
   )
   
 })
@@ -191,7 +193,9 @@ test_that("visit_sequence correlation order with weight_var", {
         dplyr::where(is.numeric), 
         method = "correlation", 
         cor_var = "famsize"
-      )
+      ),
+    regexp = "`weight_var` isn't in conf_data",
+    fixed = TRUE
   )
   
 })
@@ -215,7 +219,9 @@ test_that("visit_sequence proportion order", {
     acs_roadmap_nw %>%
       add_sequence_numeric(where(is.numeric), 
                            method = "proportion",
-                           cor_var = "famsize")
+                           cor_var = "famsize"),
+    regexp = "`cor_var` is unnecessary if method is not 'correlation'",
+    fixed = TRUE
   )
   
 })
@@ -289,7 +295,9 @@ test_that("visit_sequence weighted total", {
       add_sequence_numeric(
         dplyr::where(is.numeric), 
         method = "weighted total"
-      )
+      ),
+    regexp = "One of the weighted methods is specified but weight_var is NULL",
+    fixed = TRUE
   )
   
 })
@@ -527,7 +535,10 @@ test_that("visit_sequence with factors and keeping weight (entropy)", {
 test_that("visit_sequence weighted method with weight_var = NULL throws error", {
   expect_error(
     acs_roadmap_w %>%
-      add_sequence_numeric(everything(), method = "weighted absolute total"))
+      add_sequence_numeric(everything(), method = "weighted absolute total"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
+  )
 })
 
 
@@ -537,7 +548,10 @@ test_that("error when synthesizing weight when the weight is in the start_data",
     roadmap(conf_data = acs_conf_nw, start_data = acs_start) %>%
       update_visit_sequence(weight_var = wgt) %>%
       add_sequence_numeric(dplyr::where(is.numeric), 
-                           method = "absolute weighted total"))
+                           method = "absolute weighted total"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
+  )
   
 })
 
@@ -549,7 +563,9 @@ test_that("cannot rebuild built sequence", {
     add_sequence_numeric(where(is.numeric), method = "proportion")
   
   expect_error(
-    update_visit_sequence(nr, weight_var = wgt)
+    update_visit_sequence(nr, weight_var = wgt),
+    regexp = "Cannot update_visit_sequence(roadmap, ...) if sequence already built. \n         Please call reset_visit_sequence(roadmap) first.",
+    fixed = TRUE
   )
     
 })
@@ -578,7 +594,9 @@ test_that("add_sequence_numeric() correlation with NA", {
     acs_roadmap_na %>%
       add_sequence_numeric(dplyr::where(is.numeric),
                            method = "correlation",
-                           cor_var = "age")
+                           cor_var = "age"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
   )
   
   # use na.rm == TRUE and confirm results
@@ -604,7 +622,9 @@ test_that("add_sequence_numeric() proportion with NA", {
   expect_error(
     acs_roadmap_na %>%
       add_sequence_numeric(dplyr::where(is.numeric),
-                           method = "proportion")
+                           method = "proportion"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
   )
   
   # use na.rm == TRUE and confirm results
@@ -631,7 +651,9 @@ test_that("add_sequence_numeric() weighted total with NA", {
       update_visit_sequence(weight_var = wgt,
                             synthesize_weight = FALSE) %>%
       add_sequence_numeric(dplyr::where(is.numeric),
-                           method = "weighted total")
+                           method = "weighted total"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
   )
   
   # use na.rm == TRUE and confirm results
@@ -661,7 +683,9 @@ test_that("add_sequence_numeric() absolute weighted total with NA", {
       update_visit_sequence(weight_var = wgt,
                             synthesize_weight = FALSE) %>%
       add_sequence_numeric(dplyr::where(is.numeric),
-                           method = "absolute weighted total")
+                           method = "absolute weighted total"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
   )
   
   # use na.rm == TRUE and confirm results
@@ -690,7 +714,9 @@ test_that("add_sequence_numeric() weighted absolute total with NA", {
       update_visit_sequence(weight_var = wgt,
                             synthesize_weight = FALSE) %>%
       add_sequence_numeric(dplyr::where(is.numeric),
-                           method = "weighted absolute total")
+                           method = "weighted absolute total"),
+    regexp = "Only default and manual methods are supported for numeric \n      data with NA unless na.rm = TRUE",
+    fixed = TRUE
   )
   
   # use na.rm == TRUE and confirm results

--- a/tests/testthat/test-yeo_johnson.R
+++ b/tests/testthat/test-yeo_johnson.R
@@ -5,17 +5,23 @@ test_that("yeo_johnson expected errors", {
   
   # derivative negative value
   expect_error(
-    yeo_johnson(x_vals, lambda = 1, derivative = -1)
+    yeo_johnson(x_vals, lambda = 1, derivative = -1),
+    regexp = "argument 'derivative' must be a non-negative integer",
+    fixed = TRUE
   )
   
   # epsilon negative value
   expect_error(
-    yeo_johnson(x_vals, lambda = 1, epsilon = -1)
+    yeo_johnson(x_vals, lambda = 1, epsilon = -1),
+    regexp = "argument 'epsilon' must be a single positive number",
+    fixed = TRUE
   )
   
   # inverse with non-zero derivative
   expect_error(
-    yeo_johnson(x_vals, lambda = 1, derivative = 1, inverse = TRUE)
+    yeo_johnson(x_vals, lambda = 1, derivative = 1, inverse = TRUE),
+    regexp = "argument 'derivative' must 0 when inverse = TRUE",
+    fixed = TRUE
   )
   
 })


### PR DESCRIPTION
This PR only adds `regexp` arguments to `expect_error()` calls based on current messages. I will create new issues for uninformative messages that require better error handling or fixing unexpected behavior.