### PR TITLE
Save incomplete syntheses in memory

### DIFF
--- a/R/postsynth.R
+++ b/R/postsynth.R
@@ -3,7 +3,6 @@
 #' 
 #' Postsynth objects are automatically created by `synthesize()`; package
 #' users should never need to manually create instances.
-#' 
 #' @param synthetic_data A synthetic data set.
 #' @param jth_preprocessing A list of recipes from `library(recipe)`.
 #' @param total_synthesis_time A double with the total time of synthesis.

--- a/R/postsynth.R
+++ b/R/postsynth.R
@@ -1,11 +1,19 @@
+#' 
 #' Create a postsynth object
-#'
+#' 
+#' Postsynth objects are automatically created by `synthesize()`; package
+#' users should never need to manually create instances.
+#' 
 #' @param synthetic_data A synthetic data set.
 #' @param jth_preprocessing A list of recipes from `library(recipe)`.
 #' @param total_synthesis_time A double with the total time of synthesis.
 #' @param jth_synthesis_time A vector or dataframe of synthesis times. 
 #' @param extractions A list with extracted output from the synthesis model.
 #' @param ldiversity A vector or dataframe of ldiversity stats. 
+#' @param roadmap A `roadmap` instance.
+#' @param synth_spec A `synth_spec` instance.
+#' @param workflows A named list of constructed synthesis components.
+#' @param roles A vector mapping variable names to `presynth` roles. 
 #'
 #' @return A `postsynth` object.
 #' @noRd
@@ -15,7 +23,11 @@ postsynth <- function(synthetic_data,
                       total_synthesis_time,
                       jth_synthesis_time,
                       extractions,
-                      ldiversity) {
+                      ldiversity,
+                      roadmap = NULL,
+                      synth_spec = NULL,
+                      workflows = NULL,
+                      roles = NULL) {
   
   # create new_postsynth
   postsynth <- new_postsynth(synthetic_data = synthetic_data,
@@ -23,14 +35,22 @@ postsynth <- function(synthetic_data,
                              total_synthesis_time = total_synthesis_time,
                              jth_synthesis_time = jth_synthesis_time,
                              extractions = extractions,
-                             ldiversity = ldiversity)
+                             ldiversity = ldiversity,
+                             roadmap = roadmap,
+                             synth_spec = synth_spec,
+                             workflows = workflows,
+                             roles = roles)
   
   return(postsynth)    
   
 }
 
 # constructor (for experienced users only)
-new_postsynth <- function(synthetic_data,
+new_postsynth <- function(roadmap,
+                          synth_spec,
+                          workflows,
+                          roles,
+                          synthetic_data,
                           jth_preprocessing,
                           total_synthesis_time,
                           jth_synthesis_time,
@@ -46,11 +66,15 @@ new_postsynth <- function(synthetic_data,
     total_synthesis_time = total_synthesis_time,
     jth_synthesis_time = jth_synthesis_time,
     extractions = extractions,
-    ldiversity = ldiversity
+    ldiversity = ldiversity,
+    roadmap = roadmap,
+    synth_spec = synth_spec,
+    workflows = workflows,
+    roles = roles
   )
   
   # create class
-  postsynth <- structure(postsynth, class = "postsynth")
+  postsynth <- structure(postsynth, class = c("postsynth", "presynth"))
   
   return(postsynth)
   

--- a/R/presynth.R
+++ b/R/presynth.R
@@ -73,6 +73,33 @@
 }
 
 
+#'
+#' Construct tidysynthesis roles from a `roadmap`
+#' 
+#' @param roadmap A `roadmap` object
+#' 
+#' @return A named vector of roles
+#' @noRd
+#' 
+#
+.init_roles <- function(roadmap) {
+  
+  # assign each start variable "start" role
+  start_vars <- stats::setNames(
+    rep("start", length(names(roadmap[["start_data"]]))), 
+    names(roadmap[["start_data"]])
+  )
+  
+  # assign each visit sequence variable "unsynthesized" role
+  seq_vars <- stats::setNames(
+    rep("unsynthesized", 
+        length(roadmap[["visit_sequence"]][["visit_sequence"]])),
+    roadmap[["visit_sequence"]][["visit_sequence"]]
+  )
+  
+  return(c(start_vars, seq_vars))
+  
+}
 
 #' Create a presynth object
 #'
@@ -149,11 +176,15 @@ new_presynth <- function(roadmap,
   # create workflows 
   workflows <- .construct_workflows(roadmap, synth_spec)
   
+  # create role
+  roles <- .init_roles(roadmap)
+  
   # create presynth
   presynth <- list(
     roadmap = roadmap,
     synth_spec = synth_spec,
-    workflows = workflows
+    workflows = workflows,
+    roles = roles
   )
   presynth <- structure(presynth, class = "presynth")
   
@@ -434,6 +465,11 @@ update_presynth <- function(presynth,
     roadmap = presynth[["roadmap"]], 
     synth_spec = presynth[["synth_spec"]]
   )
+  
+  # finally, reconstruct roles
+  presynth[["roles"]] <- .init_roles(presynth[["roadmap"]])
+  
+  # validate
   .validate_presynth(presynth)
   
   return(presynth)

--- a/R/synthesize.R
+++ b/R/synthesize.R
@@ -1,12 +1,12 @@
 #' Synthesize a data set
 #'
 #' @param presynth A `presynth` object created by `presynth()`.
-#' @param progress Logical, if true, displays progress. Default is `False`, no 
-#' progress displayed..
-#' @param keep_workflows Logical, if true, returns derived roadmap components 
-#' in `postsynth`(s). Default is `False`. 
-#' @param keep_partial Logical, if true, saves partial synthesis to output. 
-#' Default is `False`, no intermediate outputs saved. 
+#' @param progress Logical, if TRUE, displays progress. Default is `FALSE`, no 
+#' progress displayed.
+#' @param keep_workflows Logical, if TRUE, returns derived roadmap components 
+#' in `postsynth`(s). Default is `FALSE`. 
+#' @param keep_partial Logical, if TRUE, saves partial synthesis to output. 
+#' Default is `FALSE`, no intermediate outputs saved. 
 #'
 #' @return A postsynth object.
 #' 
@@ -414,9 +414,7 @@ synthesize <- function(presynth,
     
     # update roles
     output_roles <- presynth$roles 
-    for (n in colnames(syntheses$synth_data)) {
-      output_roles[n] <- "synthesized"
-    }
+    output_roles[colnames(syntheses$synth_data)] <- "synthesized"
     
     # create postsynth object
     postsynth <- postsynth(
@@ -449,9 +447,8 @@ synthesize <- function(presynth,
       
       # update roles
       output_roles <- presynth$roles 
-      for (n in colnames(syntheses[[replicate_number]]$synth_data)) {
-        output_roles[n] <- "synthesized"
-      }
+      output_roles[
+        colnames(syntheses[[replicate_number]]$synth_data)] <- "synthesized"
       
       # create the postsynth object
       postsynths[[replicate_number]] <- postsynth(

--- a/R/synthesize.R
+++ b/R/synthesize.R
@@ -1,7 +1,12 @@
 #' Synthesize a data set
 #'
 #' @param presynth A `presynth` object created by `presynth()`.
-#' @param progress A single logical. Should a progress be displayed?
+#' @param progress Logical, if true, displays progress. Default is `False`, no 
+#' progress displayed..
+#' @param keep_workflows Logical, if true, returns derived roadmap components 
+#' in `postsynth`(s). Default is `False`. 
+#' @param keep_partial Logical, if true, saves partial synthesis to output. 
+#' Default is `False`, no intermediate outputs saved. 
 #'
 #' @return A postsynth object.
 #' 
@@ -40,7 +45,10 @@
 #' postsynth1 <- synthesize(presynth = presynth1)
 #' 
 #' @export
-synthesize <- function(presynth, progress = FALSE) {
+synthesize <- function(presynth, 
+                       progress = FALSE,
+                       keep_workflows = FALSE,
+                       keep_partial = FALSE) {
   
   # this block is exclusively used to handle end-to-end replicates
   # all main functionality occurs below in .synthesize()
@@ -68,7 +76,10 @@ synthesize <- function(presynth, progress = FALSE) {
   
 }
 
-.synthesize <- function(presynth, progress = FALSE) {
+.synthesize <- function(presynth, 
+                        progress = FALSE,
+                        keep_workflows = FALSE,
+                        keep_partial = FALSE) {
   
   # start overall synthesis time
   synth_start_time <- Sys.time()
@@ -180,56 +191,93 @@ synthesize <- function(presynth, progress = FALSE) {
     
     for (var_j in seq_along(models)) {
       
-      message(paste0("Synthesizing ", var_j, "/", length(vs_names), " ", vs_names[[var_j]], "... "))
+      message(paste0("Synthesizing ", 
+                     var_j, 
+                     "/", 
+                     length(vs_names), 
+                     " ", 
+                     vs_names[[var_j]], 
+                     "... "))
       
-      jth_variable <- synthesize_j(
-        conf_data = conf_data,
-        synth_data = engine_output$synth_data,
-        col_schema = col_schema[[var_j]], 
-        model = models[[var_j]],
-        recipe = recipes[[var_j]],
-        sampler = samplers[[var_j]],
-        noise = noises[[var_j]],
-        tuner = tuners[[var_j]],
-        extractor = extractors[[var_j]],
-        constraints = constraints[[var_j]],
-        invert_transformations = invert_transformations,
-        p = p
+      tryCatch(
+        expr = {
+          jth_variable <- synthesize_j(
+            conf_data = conf_data,
+            synth_data = engine_output$synth_data,
+            col_schema = col_schema[[var_j]], 
+            model = models[[var_j]],
+            recipe = recipes[[var_j]],
+            sampler = samplers[[var_j]],
+            noise = noises[[var_j]],
+            tuner = tuners[[var_j]],
+            extractor = extractors[[var_j]],
+            constraints = constraints[[var_j]],
+            invert_transformations = invert_transformations,
+            p = p
+          )
+          
+          # put together synthetic data set
+          engine_output$synth_data <- dplyr::bind_cols(
+            engine_output$synth_data, jth_variable$predictions
+          )
+          
+          # use _NA variables to add NA to their corresponding variables
+          if (presynth$synth_spec$enforce_na) {
+            
+            engine_output$synth_data <- enforce_na(data = engine_output$synth_data)
+            
+          }
+          
+          # add estimated model for the jth variable
+          engine_output$jth_preprocessing[[var_j]] <- (
+            jth_variable[["estimated_model"]][["pre"]][["mold"]][[
+              "blueprint"]][["recipe"]]
+          )
+          
+          # add synthesis time for the jth variable
+          engine_output$jth_synthesis_time[var_j] <- jth_variable$jth_synthesis_time
+          
+          engine_output$extractions[[var_j]] <- jth_variable$extraction
+          
+          # add ldiversity for the jth variable
+          if (!is.null(jth_variable$ldiversity)) {
+            
+            engine_output$ldiversity[[var_j]] <- jth_variable$ldiversity
+            
+          }
+          
+          return(engine_output)
+          
+        },
+        error = \(e) {
+          
+          if (keep_partial) {
+            
+            stop_var_name <- col_schema[[var_j]]
+            
+            warning(
+              "Error encountered in variable "
+            )
+            
+            return(
+              list(synth_data = synth_data,
+                   jth_preprocessing = jth_preprocessing,
+                   jth_synthesis_time = jth_synthesis_time,
+                   extractions = extractions,
+                   ldiversity = ldiversity)
+            )
+            
+          } else {
+            
+            stop(e)
+            
+          }
+          
+        }
+        
       )
       
-      # put together synthetic data set
-      engine_output$synth_data <- dplyr::bind_cols(
-        engine_output$synth_data, jth_variable$predictions
-      )
-      
-      # use _NA variables to add NA to their corresponding variables
-      if (presynth$synth_spec$enforce_na) {
-        
-        engine_output$synth_data <- enforce_na(data = engine_output$synth_data)
-        
-      }
-      
-      # add estimated model for the jth variable
-      engine_output$jth_preprocessing[[var_j]] <- (
-        jth_variable[["estimated_model"]][["pre"]][["mold"]][[
-          "blueprint"]][["recipe"]]
-      )
-      
-      # add synthesis time for the jth variable
-      engine_output$jth_synthesis_time[var_j] <- jth_variable$jth_synthesis_time
-      
-      engine_output$extractions[[var_j]] <- jth_variable$extraction
-      
-      # add ldiversity for the jth variable
-      if (!is.null(jth_variable$ldiversity)) {
-        
-        engine_output$ldiversity[[var_j]] <- jth_variable$ldiversity
-        
-      }
-        
     }
-    
-    return(engine_output)
     
   }
   
@@ -327,6 +375,21 @@ synthesize <- function(presynth, progress = FALSE) {
     
   }
   
+  # presynth caching logic 
+  keep_roadmap <- NULL
+  keep_synth_spec <- NULL
+  keep_workflow <- NULL
+  keep_roles <- NULL
+  
+  if (keep_workflows) {
+    
+    keep_roadmap <- presynth$roadmap
+    keep_synth_spec <- presynth$synth_spec
+    keep_workflow <- presynth$workflows
+    keep_roles <- presynth$roles
+    
+  }
+  
   # if only one replicate, return a postsynth object directly
   if (length(syntheses) == 1) {
     
@@ -350,7 +413,11 @@ synthesize <- function(presynth, progress = FALSE) {
                                         units = "secs"),
       jth_synthesis_time = jth_synthesis_time,
       extractions = syntheses$extractions,
-      ldiversity = tibble::as_tibble(data.frame(syntheses$ldiversity))
+      ldiversity = tibble::as_tibble(data.frame(syntheses$ldiversity)),
+      roadmap = keep_roadmap,
+      synth_spec = keep_synth_spec,
+      workflows = keep_workflow,
+      roles = keep_roles
     )
     
     return(postsynth)
@@ -377,7 +444,11 @@ synthesize <- function(presynth, progress = FALSE) {
         extractions = syntheses[[replicate_number]]$extractions,
         ldiversity = tibble::as_tibble(
           data.frame(syntheses[[replicate_number]]$ldiversity)
-        )
+        ),
+        roadmap = keep_roadmap,
+        synth_spec = keep_synth_spec,
+        workflows = keep_workflow,
+        roles = keep_roles
       )
 
     }
@@ -387,3 +458,4 @@ synthesize <- function(presynth, progress = FALSE) {
   }
 
 }
+

--- a/man/synthesize.Rd
+++ b/man/synthesize.Rd
@@ -4,12 +4,24 @@
 \alias{synthesize}
 \title{Synthesize a data set}
 \usage{
-synthesize(presynth, progress = FALSE)
+synthesize(
+  presynth,
+  progress = FALSE,
+  keep_workflows = FALSE,
+  keep_partial = FALSE
+)
 }
 \arguments{
 \item{presynth}{A \code{presynth} object created by \code{presynth()}.}
 
-\item{progress}{A single logical. Should a progress be displayed?}
+\item{progress}{Logical, if true, displays progress. Default is \code{False}, no
+progress displayed..}
+
+\item{keep_workflows}{Logical, if true, returns derived roadmap components
+in \code{postsynth}(s). Default is \code{False}.}
+
+\item{keep_partial}{Logical, if true, saves partial synthesis to output.
+Default is \code{False}, no intermediate outputs saved.}
 }
 \value{
 A postsynth object.

--- a/man/synthesize.Rd
+++ b/man/synthesize.Rd
@@ -14,14 +14,14 @@ synthesize(
 \arguments{
 \item{presynth}{A \code{presynth} object created by \code{presynth()}.}
 
-\item{progress}{Logical, if true, displays progress. Default is \code{False}, no
-progress displayed..}
+\item{progress}{Logical, if TRUE, displays progress. Default is \code{FALSE}, no
+progress displayed.}
 
-\item{keep_workflows}{Logical, if true, returns derived roadmap components
-in \code{postsynth}(s). Default is \code{False}.}
+\item{keep_workflows}{Logical, if TRUE, returns derived roadmap components
+in \code{postsynth}(s). Default is \code{FALSE}.}
 
-\item{keep_partial}{Logical, if true, saves partial synthesis to output.
-Default is \code{False}, no intermediate outputs saved.}
+\item{keep_partial}{Logical, if TRUE, saves partial synthesis to output.
+Default is \code{FALSE}, no intermediate outputs saved.}
 }
 \value{
 A postsynth object.

--- a/tests/testthat/test-presynth.R
+++ b/tests/testthat/test-presynth.R
@@ -66,6 +66,27 @@ test_that("presynth() creates a basic presynth object", {
 
 })
 
+test_that("presynth() creates expected roles", {
+  
+  expect_warning(
+    presynth <- presynth(roadmap = roadmap,
+                         synth_spec = synth_spec)
+  )
+  
+  expect_true(
+    all(presynth[["roles"]][names(roadmap[["start_data"]])] == "start")
+  )
+  
+  expect_true(
+    all(
+      presynth[["roles"]][
+        roadmap[["visit_sequence"]][["visit_sequence"]]] == "unsynthesized"
+    )
+  )
+  
+  
+})
+
 test_that("presynth input errors", {
   
   expect_error(

--- a/tests/testthat/test-synthesis-control-flow.R
+++ b/tests/testthat/test-synthesis-control-flow.R
@@ -1,0 +1,78 @@
+start_data <- dplyr::select(mtcars, cyl, vs, am)
+
+roadmap1 <- roadmap(conf_data = mtcars,
+                   start_data = start_data) |> 
+  add_sequence_numeric(everything(), method = "correlation", cor_var = "mpg")
+
+
+dt_mod <- parsnip::decision_tree() |>
+  parsnip::set_engine(engine = "rpart") |>
+  parsnip::set_mode(mode = "regression")
+
+synth_spec <- synth_spec(default_regression_model = dt_mod,
+                         default_regression_sampler = sample_rpart)
+
+suppressWarnings(
+  {
+    working_presynth <- presynth(roadmap = roadmap1,
+                                 synth_spec = synth_spec)
+    failing_presynth <- presynth(roadmap = roadmap1,
+                                 synth_spec = synth_spec) 
+  }
+)
+
+suppressMessages(
+  { full_result <- synthesize(working_presynth) }
+)
+
+# intentionally modify the confidential data to induce an error in `qsec`
+failing_presynth$roadmap$conf_data$qsec[1] <- "not_a_float"
+
+
+test_that("Basic functionality for saving partially synthetic data", {
+    
+    # if we try to synthesize the failing_presynth, we raise expected errors
+    expect_error({ synthesize(failing_presynth) }, 
+                 regexp = "`qsec` must have class") 
+    
+    # if we try to synthesize with keep_partial, we raise a warning that 
+    # contains the error described above.
+    expect_warning(
+      { partial_result <- synthesize(failing_presynth, keep_partial = TRUE) },
+      regexp = "Error encountered in variable 'qsec'.*`qsec` must have class"
+    )
+    
+    # expect the failing variable to be the last in the visit_sequence (by
+    # construction in the roadmap)
+    expect_equal(tail(roadmap1$visit_sequence$visit_sequence, n=1), "qsec")
+    
+    # because the last variable fails, expect the complete result to be one
+    # variable shorter than the partial result
+    expect_equal(ncol(full_result$synthetic_data), 11)
+    expect_equal(ncol(partial_result$synthetic_data), 10)
+    
+    # expect roles to reflect the incomplete synthesis
+    expect_true(all(full_result$roles[3:11] == "synthesized"))
+    expect_equal(partial_result$roles[["qsec"]], "unsynthesized")
+    expect_true(all(partial_result$roles[3:10] == "synthesized"))
+    
+
+})
+
+
+test_that("Basic functionality for saving workflows", {
+  
+  expect_no_error({ full_result_cached <- synthesize(working_presynth,
+                                                     keep_workflows = TRUE) })
+  
+  # expect keep_workflows components saved in full result, not by default
+  expect_true(is.null(full_result$roadmap))
+  expect_true(is.null(full_result$synth_spec))
+  expect_true(is.null(full_result$workflows))
+  expect_false(is.null(full_result_cached$roadmap))
+  expect_false(is.null(full_result_cached$synth_spec))
+  expect_false(is.null(full_result_cached$workflows))
+  
+})
+
+


### PR DESCRIPTION
This PR adds two new arguments to `synthesize()` that handle errors during `synthesize_j()`, allowing intermediate incomplete syntheses to be accessed and saved. 

```
#' @param keep_workflows Logical, if true, returns derived roadmap components 
#' in `postsynth`(s). Default is `False`. 
#' @param keep_partial Logical, if true, saves partial synthesis to output. 
#' Default is `False`, no intermediate outputs saved. 
```

To accommodate this, we make `postsynth` contain a superset of `presynth` slots, including `roles` which determines whether a variable was successfully synthesized or not. 

For a complete working example see the tests in `test-synthesis-control-flow.R`

