### PR TITLE
add NA handling to enforce schema

### DIFF
--- a/R/enforce_schema.R
+++ b/R/enforce_schema.R
@@ -249,8 +249,13 @@ enforce_schema <- function(roadmap) {
     
     # Update the col_schema to include _NA variables
     for (var in names(conf_data)) {                                                                                     
-      if (endsWith(var, "_NA") && is.null(col_schema[[var]])) {                                                         
-        col_schema[[var]] <- list(dtype = "fct", levels = NULL, na_value = NA, na_prop = 0)                             
+      if (endsWith(var, "_NA")) { 
+        
+        col_schema[[var]] <- list(
+          "dtype" = "fct",
+          "na_prop" = 0., 
+          "levels" = c("missing value", "nonmissing value")
+        )
       }                                                                                                                 
     }           
   }

--- a/R/enforce_schema.R
+++ b/R/enforce_schema.R
@@ -247,6 +247,12 @@ enforce_schema <- function(roadmap) {
                            types = c("int", "dbl"),
                            skip_vars = names(start_data))
     
+    # Update the col_schema to include _NA variables
+    for (var in names(conf_data)) {                                                                                     
+      if (endsWith(var, "_NA") && is.null(col_schema[[var]])) {                                                         
+        col_schema[[var]] <- list(dtype = "fct", levels = NULL, na_value = NA, na_prop = 0)                             
+      }                                                                                                                 
+    }           
   }
   
   # if flagged, convert missing factor values into a new factor level

--- a/tests/testthat/test-synthesize-example_na.R
+++ b/tests/testthat/test-synthesize-example_na.R
@@ -121,10 +121,8 @@ test_that("synthesis with enforce_na = FALSE", {
 
 test_that("postsynth_to_roadmap works with partial synthesis containing _NA variables", {
 
- # This test addresses a bug where _NA indicator variables are added to
- # synth_vars but not to col_schema in enforce_schema(). This causes
- # postsynth_to_roadmap() to fail when called on a partial synthesis result
- # where _NA variables remain unsynthesized. The error was thrown in 
+ # This test checks that {variable}_NA columns are added the schema in roadmap. 
+ # It is important that they are added because they are considered in 
  # constraints.R when calling schema[["col_schema"]][[x]][["dtype"]]. 
 
   # Setup: use data with missing values 

--- a/tests/testthat/test-synthesize-example_na.R
+++ b/tests/testthat/test-synthesize-example_na.R
@@ -116,5 +116,55 @@ test_that("synthesis with enforce_na = FALSE", {
     unname()
   
   expect_equal(missing_values2,  c(0, 23, 20, 13, 122))
-  
+
+})
+
+test_that("postsynth_to_roadmap works with partial synthesis containing _NA variables", {
+
+ # This test addresses a bug where _NA indicator variables are added to
+ # synth_vars but not to col_schema in enforce_schema(). This causes
+ # postsynth_to_roadmap() to fail when called on a partial synthesis result
+ # where _NA variables remain unsynthesized. The error was thrown in 
+ # constraints.R when calling schema[["col_schema"]][[x]][["dtype"]]. 
+
+  # Setup: use data with missing values (wages has NAs, so wages_NA will be created)
+  starting_data <- example_na |>
+    dplyr::select(age)
+
+  roadmap_test <- roadmap(
+    conf_data = dplyr::select(example_na, -health),
+    start_data = starting_data
+  )
+
+  synth_spec_test <- synth_spec(
+    default_regression_model = rpart_mod,
+    default_classification_model = rpart_mod_cat,
+    default_regression_sampler = sample_rpart,
+    default_classification_sampler = sample_rpart
+  )
+
+  expect_warning(
+    presynth_test <- presynth(
+      roadmap = roadmap_test,
+      synth_spec = synth_spec_test
+    )
+  )
+
+  # Corrupt age (early in visit sequence) to cause synthesis failure
+  presynth_test$roadmap$conf_data$age[1:5] <- "corrupted"
+
+  # Synthesize with keep_partial = TRUE and keep_workflows = TRUE
+  # This will produce warnings but continue
+  expect_warning(
+    result <- synthesize(presynth_test, 
+                         keep_partial = TRUE, 
+                         keep_workflows = TRUE)
+  )
+
+  # This should give us the returned roadmap and work successfully to return a value
+  expect_no_error(
+    new_roadmap <- postsynth_to_roadmap(result)
+  )
+
+
 })

--- a/tests/testthat/test-synthesize-example_na.R
+++ b/tests/testthat/test-synthesize-example_na.R
@@ -127,7 +127,7 @@ test_that("postsynth_to_roadmap works with partial synthesis containing _NA vari
  # where _NA variables remain unsynthesized. The error was thrown in 
  # constraints.R when calling schema[["col_schema"]][[x]][["dtype"]]. 
 
-  # Setup: use data with missing values (wages has NAs, so wages_NA will be created)
+  # Setup: use data with missing values 
   starting_data <- example_na |>
     dplyr::select(age)
 


### PR DESCRIPTION
Fix bug outlined in #46 ! 

Some other commentary is that this code addresses this issue with `construct_col_schema.R`! However, we use that function to handle the col_schema in `presynth`. This issue is with the `col_schema` in `roadmap`. The solution I implemented is modeled after that fix.

Also adding a test to address this specific issue


All tests passing: 
 ```

══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 22.0 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 984 ]
```