### PR TITLE
updating enforce_na

### DIFF
--- a/R/enforce_na.R
+++ b/R/enforce_na.R
@@ -20,7 +20,6 @@ enforce_na <- function(data) {
   #   var_names_NA: var_names that end in _NA
   #   var_names_missing_values: var_names for variables with missing values
   var_names <- names(data)
-  
   var_names_NA <- var_names[stringr::str_detect(var_names, pattern = "_NA$")]
   
   # stop if there are no _NA variables
@@ -31,32 +30,25 @@ enforce_na <- function(data) {
   # stop if the relevant variable isn't present yet
   if (any(!var_names_missing_values %in% var_names)) return(data)
   
-  # create a helper function to inject NA into locations where the _NA var says 
-  # there should be an NA
-  inject_na <- function(data, x) {
-    
-    x_NA <- paste0(x, "_NA")
-    
-    for (row in 1:nrow(data)) {
-      
-      data[row, x] <- dplyr::if_else(
-        condition = data[row, x_NA, drop = TRUE] == "missing value", 
-        true = NA, 
-        false = data[row, x, drop = TRUE]
-      )
-      
-    }
-    
-    return(data)
-    
-  }
+  # Process:
+  #(1) Create a mask matrix with nrow(data) rows and columns for each of the
+  #.      columns with NA values. This is mask
+  #(2) Extract columns with relevant values to be replaced with NA. This is values 
+  #(3) Use mask to update values to NA where mask says so
+  #(4) Update data's relevant columns with values
   
-  # iterate inject_na over variables that should have NA
-  for (var in var_names_missing_values) {
-    
-    data <- inject_na(data = data, x = var)
-    
-  }
+  
+  # Step 1: Create mask
+  mask <- as.matrix(data[var_names_NA] == "missing value")
+  
+  # Step 2: Extract columns 
+  values <- data[var_names_missing_values]
+  
+  # Step 3: Apply the mask to update values to NA
+  values[mask] <- NA
+  
+  # Step 4: Write the updated columns back
+  data[var_names_missing_values] <- values
   
   return(data)
   


### PR DESCRIPTION
Resolves solve `enforce_na` functionality by moving from a set of for loops to using masking operations. 


Code passes all current tests:
```
devtools::test()
ℹ Testing tidysynthesis
✔ | F W  S  OK | Context
✔ |         13 | add_noise_cat_unif                                                                                                 
✔ |          7 | add_noise_disc_gaussian                                                                                            
✔ |          7 | add_noise_disc_laplace                                                                                             
✔ |          5 | add_noise_gaussian                                                                                                 
✔ |         12 | add_noise_kde                                                                                                      
✔ |          5 | add_noise_laplace                                                                                                  
✔ |          3 | assign_constraints                                                                                                 
✔ |          3 | calc_bandwidths                                                                                                    
✔ |          2 | collapse_na                                                                                                        
✔ |         47 | constraints                                                                                                        
✔ |         15 | construct_extractors                                                                                               
✔ |         23 | construct_models                                                                                                   
✔ |         10 | construct_noise                                                                                                    
✔ |         28 | construct_recipes [5.1s]                                                                                           
✔ |         14 | construct_samplers                                                                                                 
✔ |         17 | construct_tuners                                                                                                   
✔ |          8 | convert_level_to_na                                                                                                
✔ |          7 | convert_na_to_level                                                                                                
✔ |         17 | create_ntiles                                                                                                      
✔ |          3 | enforce_na                                                                                                         
✔ |         57 | enforce_schema                                                                                                     
✔ |         15 | expand_na                                                                                                          
✔ |          9 | garnish                                                                                                            
✔ |          8 | invert                                                                                                             
✔ |          5 | ks_distance                                                                                                        
✔ |         11 | noise                                                                                                              
✔ |          4 | postsynth                                                                                                          
✔ |         31 | presynth                                                                                                           
✔ |         24 | replicates                                                                                                         
✔ |         29 | reset_postsynth                                                                                                    
✔ |         36 | roadmap                                                                                                            
✔ |   1     17 | sample_glm                                                                                                         
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Warning (test-sample_glm.R:1:1): (code run outside of `test_that()`)
package ‘parsnip’ was built under R version 4.5.2
Backtrace:
    ▆
 1. └─base::library(poissonreg) at test-sample_glm.R:1:1
 2.   └─base::.getRequiredPackages2(...)
 3.     └─base::library(...)
 4.       └─base (local) testRversion(pkgInfo, package, pkgpath)
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
✔ |         12 | sample_lm                                                                                                          
✔ |         16 | sample_ranger [3.8s]                                                                                               
✔ |         30 | sample_rpart [1.3s]                                                                                                
✔ |         34 | schema                                                                                                             
✔ |         31 | start_method                                                                                                       
✔ |         21 | start_resample [1.0s]                                                                                              
✔ |         29 | synth_component_utils                                                                                              
✔ |         53 | synth_spec                                                                                                         
✔ |         10 | synthesis_categorical                                                                                              
✔ |         16 | synthesis-constraints-cat                                                                                          
✔ |         18 | synthesis-constraints-num                                                                                          
✔ |         15 | synthesis-control-flow                                                                                             
✔ |         10 | synthesis-empty-factor                                                                                             
✔ |          4 | synthesis-hyperparameters                                                                                          
✔ |         10 | synthesis-messages                                                                                                 
✔ |          2 | synthesize_basic                                                                                                   
✔ |         16 | synthesize_j                                                                                                       
✔ |          9 | synthesize-example_na                                                                                              
✔ |          4 | synthesize-factor-first                                                                                            
✔ |         12 | synthesize-replicates [2.5s]                                                                                       
✔ |         18 | synthesize                                                                                                         
✔ |         11 | tune_synthesis                                                                                                     
✔ |         95 | visit_sequence_api                                                                                                 
✔ |         16 | visit_sequence                                                                                                     

══ Results ═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 23.5 s

[ FAIL 0 | WARN 1 | SKIP 0 | PASS 984 ]
Warning message:
package ‘testthat’ was built under R version 4.5.2 
```
