### PR TITLE
Fix mismatched visit_sequence and visit_method when NA indicators are inserted

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tidysynthesis (development version)
+
+* Fix mismatched `visit_sequence` and `visit_method` lengths when `enforce_schema()`
+  inserts an `_NA` indicator in the middle of the visit sequence (#52).
+
 # tidysynthesis 0.1.3
 
 * Add additional arguments to `synthesize()` for saving incomplete syntheses.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fix mismatched `visit_sequence` and `visit_method` lengths when `enforce_schema()`
   inserts an `_NA` indicator in the middle of the visit sequence (#52).
+* Fix `enforce_schema()` erroring when a numeric variable name contains, but does
+  not end in, `_NA`.
 
 # tidysynthesis 0.1.3
 

--- a/R/enforce_schema.R
+++ b/R/enforce_schema.R
@@ -286,34 +286,18 @@ enforce_schema <- function(roadmap) {
   )
   orig_vms <- purrr::map_chr(
     .x = orig_na_vars,
-    .f = \(x) { vm[[which(!is.na(match(vs, x)))]] }
+    .f = \(x) { vm[[match(x, vs)]] }
   )
   
-  # for each NA variable
+  # for each NA variable, insert the indicator immediately before its
+  # corresponding variable, keeping visit_sequence and visit_method aligned
   for (i in seq_along(na_vars)) {
     
     # find index at which to insert indicator
-    insert_ix <- which(!is.na(match(vs, orig_na_vars[[i]])))
+    insert_ix <- match(orig_na_vars[[i]], vs)
     
-    # if indicator at beginning...
-    if (insert_ix == 1) {
-      
-      vs <- c(na_vars[[i]], vs)
-      vm <- c(orig_vms[[i]], vm)
-    
-    # else if indicator at the end...
-    } else if (insert_ix == length(vs)) {
-      
-      vs <- c(vs[1:insert_ix - 1], na_vars[[i]], vs[insert_ix])
-      vm <- c(vm[1:insert_ix - 1], orig_vms[[i]], vm[insert_ix])
-    
-    # else indicator in the middle...
-    } else {
-      
-      vs <- c(vs[1:insert_ix - 1], na_vars[[i]], vs[insert_ix:length(vs)])
-      vm <- c(vm[1:insert_ix - 1], orig_vms[[i]], vm[insert_ix:length(vs)])
-      
-    }
+    vs <- append(vs, na_vars[[i]], after = insert_ix - 1)
+    vm <- append(vm, orig_vms[[i]], after = insert_ix - 1)
     
   }
   

--- a/R/enforce_schema.R
+++ b/R/enforce_schema.R
@@ -280,10 +280,7 @@ enforce_schema <- function(roadmap) {
   
   # first, get variable names with and without NA values and their indices
   na_vars <- synth_vars[endsWith(synth_vars, "_NA")]
-  orig_na_vars <- purrr::map_chr(
-    .x = na_vars, 
-    .f = \(x) { stringr::str_replace(x, '_NA', '') } 
-  )
+  orig_na_vars <- stringr::str_remove(na_vars, pattern = "_NA$")
   orig_vms <- purrr::map_chr(
     .x = orig_na_vars,
     .f = \(x) { vm[[match(x, vs)]] }

--- a/tests/testthat/test-enforce_schema.R
+++ b/tests/testthat/test-enforce_schema.R
@@ -304,3 +304,41 @@ test_that("schema_updates with NA indicators in first position", {
   
 })
 
+
+test_that("schema_updates with NA indicators in middle position", {
+  
+  # mirrors the reproducer in issue #52: a heterogeneous visit_method where
+  # inctot_NA must be inserted mid-sequence
+  old_roadmap <- roadmap(
+    conf_data = acs_conf_nw,
+    start_data = dplyr::select(acs_conf_nw, dplyr::all_of("county"))
+  ) |>
+    add_sequence_factor(where(is.factor), method = "entropy") |>
+    add_sequence_numeric(where(is.numeric), method = "proportion", na.rm = TRUE) |>
+    update_schema(na_numeric_to_ind = TRUE)
+  
+  new_roadmap <- enforce_schema(old_roadmap)
+  
+  visit_sequence <- new_roadmap[["visit_sequence"]][["visit_sequence"]]
+  visit_method <- new_roadmap[["visit_sequence"]][["visit_method"]]
+  
+  # the indicator is inserted in the middle, not at either end
+  inctot_ix <- match("inctot", visit_sequence)
+  expect_true(inctot_ix > 2 & inctot_ix < length(visit_sequence))
+  
+  # visit_sequence and visit_method must stay aligned
+  expect_equal(length(visit_sequence), length(visit_method))
+  expect_false(anyNA(visit_method))
+  
+  # indicator must be visited immediately before its variable
+  expect_equal(visit_sequence[inctot_ix - 1], "inctot_NA")
+  
+  # the indicator inherits the visit_method of its variable, which differs
+  # from the methods of the variables it is inserted between
+  expect_equal(visit_method[inctot_ix - 1], "proportion")
+  expect_true("entropy" %in% visit_method)
+  
+  # printing the visit_sequence requires equal-length columns
+  expect_no_error(print(new_roadmap[["visit_sequence"]]))
+  
+})

--- a/tests/testthat/test-enforce_schema.R
+++ b/tests/testthat/test-enforce_schema.R
@@ -342,3 +342,27 @@ test_that("schema_updates with NA indicators in middle position", {
   expect_no_error(print(new_roadmap[["visit_sequence"]]))
   
 })
+
+
+test_that("schema_updates with _NA inside a variable name", {
+  
+  # expand_na() only rejects names that end in "_NA", so a name that merely
+  # contains it must still resolve back to its original variable
+  old_roadmap <- roadmap(
+    conf_data = acs_conf |>
+      dplyr::rename(inc_NAtive = "inctot") |>
+      dplyr::relocate(dplyr::all_of("inc_NAtive"), .before = "age"), 
+    start_data = acs_start
+  ) |>
+    update_schema(na_numeric_to_ind = TRUE)
+  
+  new_roadmap <- enforce_schema(old_roadmap)
+  
+  visit_sequence <- new_roadmap[["visit_sequence"]][["visit_sequence"]]
+  
+  expect_equal(
+    visit_sequence[match("inc_NAtive", visit_sequence) - 1],
+    "inc_NAtive_NA"
+  )
+  
+})


### PR DESCRIPTION
Fixes #52.

## The bug

`enforce_schema()` inserts an `_NA` indicator immediately before its variable in the visit sequence. The middle-position branch updated `vs` before slicing `vm`:

```r
vs <- c(vs[1:insert_ix - 1], na_vars[[i]], vs[insert_ix:length(vs)])
vm <- c(vm[1:insert_ix - 1], orig_vms[[i]], vm[insert_ix:length(vs)])
```

By the second line `length(vs)` is already the new, longer length, so `vm[insert_ix:length(vs)]` reads one element past the end of `vm` and appends an `NA`. `visit_method` ends up one longer than `visit_sequence`, and printing the visit sequence fails with the reported `Size 12` / `Size 11`.

This only shows up when the indicator lands in the middle. In `acs_conf`, `inctot` is the only numeric variable with missing values and it sits last in the default sequence, which is why the existing tests pass.

The three positional branches are replaced with a single `append(after = insert_ix - 1)`, which handles the first, middle, and last cases the same way.

## One note on the issue text

The issue attributes the mutation to `enforce_na()`. Those two lines are only in `enforce_schema()`. `enforce_na()` and `convert_na_to_level()` both take and return `data` and never touch a roadmap, so no change was needed there. I also checked the other places that write both fields (`reset_postsynth.R:131`, `visit_sequence_api.R:193,327,518`) and none of them can change the lengths independently.

## Second commit

While rewriting the lookup I hit a separate latent bug, so it is in its own commit (`Anchor the _NA suffix removal...`) that you can drop by resetting to the first commit if you would rather track it on its own issue.

`expand_na()` rejects names that end in `_NA`, but allows names that merely contain it. `str_replace(x, '_NA', '')` stripped the first occurrence anywhere, so a variable named `inc_NAtive` became `inctive_NA`, matched nothing in the visit sequence, and errored. `str_remove(pattern = "_NA$")` matches the idiom already used in `collapse_na.R`, `enforce_na.R`, and `visit_sequence.R`.

## Testing

Two tests in `test-enforce_schema.R`, one per commit. The first mirrors the reproducer from the issue (`acs_conf_nw` with `entropy` and `proportion` methods) so the visit methods are heterogeneous and the inherited-method assertion is meaningful; without the fix it fails with the same `Size 12` / `Size 11`. The second covers the `inc_NAtive` case and fails against the first commit alone.

`devtools::test()` gives 992 passing, and `R CMD check` is clean apart from a NOTE for `rpart.LAD`, which is not on CRAN.

Targeting `version0.1.4` per `project-standards.md`. `NEWS.md` entries are under `# tidysynthesis (development version)`; happy to move them under a `0.1.4` heading if you prefer.
